### PR TITLE
모임페이지 정보 섹션 구현 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.1",
+        "react-icons": "^4.7.1",
         "react-router-dom": "^6.8.1",
         "recoil": "^0.7.6"
       },
@@ -5931,6 +5932,14 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11297,6 +11306,12 @@
       "version": "7.43.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.1.tgz",
       "integrity": "sha512-+s3+s8LLytRMriwwuSqeLStVjRXFGxgjjx2jED7Z+wz1J/88vpxieRQGvJVvzrzVxshZ0BRuocFERb779m2kNg==",
+      "requires": {}
+    },
+    "react-icons": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.1",
+    "react-icons": "^4.7.1",
     "react-router-dom": "^6.8.1",
     "recoil": "^0.7.6"
   },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import PartyInformation from './components/Party/PartyInformation/PartyInformation';
 
+import PartyInformation from './components/Party/PartyInformation/PartyInformation';
 import {
   MainPage,
   PartyAlbumPage,

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,14 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import PartyInformation from './components/Party/PartyInformation/PartyInformation';
 
-import { MainPage, SignUpPage } from './pages';
+import {
+  MainPage,
+  PartyAlbumPage,
+  PartyNoticePage,
+  PartyPlanPage,
+  PartySchedulePage,
+  SignUpPage,
+} from './pages';
 import ROUTES from './utils/routes';
 
 const Router = () => {
@@ -9,6 +17,12 @@ const Router = () => {
       <Routes>
         <Route path={ROUTES.MAIN} element={<MainPage />} />
         <Route path={ROUTES.SIGNUP} element={<SignUpPage />} />
+        <Route element={<PartyInformation />}>
+          <Route path={ROUTES.NOTICE} element={<PartyNoticePage />} />
+          <Route path={ROUTES.SCHEDULE} element={<PartySchedulePage />} />
+          <Route path={ROUTES.PLAN} element={<PartyPlanPage />} />
+          <Route path={ROUTES.ALBUM} element={<PartyAlbumPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Party/PartyInformation/PartyInformation.tsx
+++ b/src/components/Party/PartyInformation/PartyInformation.tsx
@@ -18,9 +18,9 @@ const PartyInformation = () => {
           <Button colorScheme='teal' size='xs' marginRight='0.625rem'>
             영수증
           </Button>
-          <button>
+          <Button bg='transparent' size='xs'>
             <BsFillShareFill />
-          </button>
+          </Button>
         </Flex>
       </Flex>
       <PartyUserList />

--- a/src/components/Party/PartyInformation/PartyInformation.tsx
+++ b/src/components/Party/PartyInformation/PartyInformation.tsx
@@ -1,9 +1,9 @@
-import { Button, Flex, Heading, Text, Image } from '@chakra-ui/react';
-import { Outlet } from 'react-router-dom';
-import { Container } from '@chakra-ui/react';
+import { Button, Container, Flex, Heading, Image, Text } from '@chakra-ui/react';
 import { BsFillShareFill } from 'react-icons/bs';
-import PartyUserList from './PartyUserList';
+import { Outlet } from 'react-router-dom';
+
 import PartyMenuTabList from './PartyMenuTabList';
+import PartyUserList from './PartyUserList';
 
 const PartyInformation = () => {
   return (

--- a/src/components/Party/PartyInformation/PartyInformation.tsx
+++ b/src/components/Party/PartyInformation/PartyInformation.tsx
@@ -1,0 +1,34 @@
+import { Button, Flex, Heading, Text, Image } from '@chakra-ui/react';
+import { Outlet } from 'react-router-dom';
+import { Container } from '@chakra-ui/react';
+import { BsFillShareFill } from 'react-icons/bs';
+import PartyUserList from './PartyUserList';
+import PartyMenuTabList from './PartyMenuTabList';
+
+const PartyInformation = () => {
+  return (
+    <>
+      <Image src='https://via.placeholder.com/500x200' />
+      <Flex justify='space-between'>
+        <Container p='0.625rem' m='0'>
+          <Heading size='md'>파티 명</Heading>
+          <Text>기간</Text>
+        </Container>
+        <Flex p='10px' textAlign='right' align='center'>
+          <Button colorScheme='teal' size='xs' marginRight='0.625rem'>
+            영수증
+          </Button>
+          <button>
+            <BsFillShareFill />
+          </button>
+        </Flex>
+      </Flex>
+      <PartyUserList />
+      <Text margin='0.625rem'>파티 소개</Text>
+      <PartyMenuTabList />
+      <Outlet />
+    </>
+  );
+};
+
+export default PartyInformation;

--- a/src/components/Party/PartyInformation/PartyMenuTabList.tsx
+++ b/src/components/Party/PartyInformation/PartyMenuTabList.tsx
@@ -1,6 +1,7 @@
-import ROUTES from '@/src/utils/routes';
 import { Tab, TabList, Tabs } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
+
+import ROUTES from '@/src/utils/routes';
 
 const partyTab = [
   {

--- a/src/components/Party/PartyInformation/PartyMenuTabList.tsx
+++ b/src/components/Party/PartyInformation/PartyMenuTabList.tsx
@@ -1,0 +1,38 @@
+import ROUTES from '@/src/utils/routes';
+import { Tab, TabList, Tabs } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+
+const partyTab = [
+  {
+    name: '공지',
+    to: ROUTES.NOTICE,
+  },
+  {
+    name: '일정',
+    to: ROUTES.SCHEDULE,
+  },
+  {
+    name: '계획',
+    to: ROUTES.PLAN,
+  },
+  {
+    name: '앨범',
+    to: ROUTES.ALBUM,
+  },
+];
+
+const PartyMenuTabList = () => {
+  return (
+    <Tabs>
+      <TabList>
+        {partyTab.map((tab) => (
+          <Link key={tab.name} to={tab.to} style={{ width: '100%' }}>
+            <Tab w='100%'>{tab.name}</Tab>
+          </Link>
+        ))}
+      </TabList>
+    </Tabs>
+  );
+};
+
+export default PartyMenuTabList;

--- a/src/components/Party/PartyInformation/PartyUserList.tsx
+++ b/src/components/Party/PartyInformation/PartyUserList.tsx
@@ -1,0 +1,35 @@
+import { Avatar, Flex, Text } from '@chakra-ui/react';
+
+const userRole = [
+  {
+    nickname: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    role: '방장',
+  },
+  {
+    nickname: '육예스',
+    profileImage: 'https://via.placeholder.com/50',
+    role: '총무',
+  },
+  {
+    nickname: '칠예스',
+    profileImage: 'https://via.placeholder.com/50',
+    role: '김기사',
+  },
+];
+
+const PartyUserList = () => {
+  return (
+    <Flex direction='row'>
+      {userRole.map((user) => (
+        <Flex key={user.role} direction='column' align='center' marginLeft='0.625rem'>
+          <Avatar src={user.profileImage} size='sm' />
+          <Text fontSize='sm'>{user.nickname}</Text>
+          <Text fontSize='xs'>{user.role}</Text>
+        </Flex>
+      ))}
+    </Flex>
+  );
+};
+
+export default PartyUserList;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,12 +6,15 @@ import { RecoilRoot } from 'recoil';
 
 import App from './App';
 
-const { Avatar, Button } = chakraTheme.components;
+const { Avatar, Button, Container, Heading, Tabs } = chakraTheme.components;
 
 const theme = extendBaseTheme({
   components: {
     Avatar,
     Button,
+    Container,
+    Heading,
+    Tabs,
   },
 });
 

--- a/src/pages/PartyAlbumPage.tsx
+++ b/src/pages/PartyAlbumPage.tsx
@@ -1,0 +1,5 @@
+const PartyAlbumPage = () => {
+  return <div>PartyAlbumPage</div>;
+};
+
+export default PartyAlbumPage;

--- a/src/pages/PartyNoticePage.tsx
+++ b/src/pages/PartyNoticePage.tsx
@@ -1,0 +1,5 @@
+const PartyNoticePage = () => {
+  return <div>PartyNoticePage</div>;
+};
+
+export default PartyNoticePage;

--- a/src/pages/PartyPlanPage.tsx
+++ b/src/pages/PartyPlanPage.tsx
@@ -1,0 +1,5 @@
+const PartyPlanPage = () => {
+  return <div>PartyPlanPage</div>;
+};
+
+export default PartyPlanPage;

--- a/src/pages/PartySchedulePage.tsx
+++ b/src/pages/PartySchedulePage.tsx
@@ -1,0 +1,5 @@
+const PartySchedulePage = () => {
+  return <div>PartySchedulePage</div>;
+};
+
+export default PartySchedulePage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,6 @@
 export { default as MainPage } from './MainPage';
 export { default as SignUpPage } from './SignUpPage';
+export { default as PartyAlbumPage } from './PartyAlbumPage';
+export { default as PartyNoticePage } from './PartyNoticePage';
+export { default as PartySchedulePage } from './PartySchedulePage';
+export { default as PartyPlanPage } from './PartyPlanPage';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,6 @@
 export { default as MainPage } from './MainPage';
-export { default as SignUpPage } from './SignUpPage';
 export { default as PartyAlbumPage } from './PartyAlbumPage';
 export { default as PartyNoticePage } from './PartyNoticePage';
-export { default as PartySchedulePage } from './PartySchedulePage';
 export { default as PartyPlanPage } from './PartyPlanPage';
+export { default as PartySchedulePage } from './PartySchedulePage';
+export { default as SignUpPage } from './SignUpPage';

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,6 +1,10 @@
 const ROUTES = {
   MAIN: '/',
   SIGNUP: '/signup',
+  NOTICE: '/notice',
+  SCHEDULE: '/schedule',
+  PLAN: '/plan',
+  ALBUM: '/album',
 } as const;
 
 export default ROUTES;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #6 

## 📖 구현 내용
- 모임페이지 정보 섹션 구현
  - 파티 명, 파티 기간 노출 부분 영역 잡기
  - 영수증 버튼, 공유 버튼 만들기
  - 파티 참여 유저 프로필, 닉네임, 역할 리스트 영역 잡기
  - 파티 소개 영역 잡기
  - 파티 메뉴 탭 router 연결

## 🖼 구현 이미지

![파티 정보 섹션](https://user-images.githubusercontent.com/107309247/220289638-73a79ea1-8ea3-45be-9acd-6845cb73ba7f.gif)

## ✅ PR 포인트 & 궁금한 점
- 커버 이미지, 프로필 이미지는 임시로 넣어둔 거라 따로 상수화하지 않았습니다!
- 기본 max-width 가 어느정도일지 몰라서 일단 500px로 잡아두고 작업하였고  max-width 잡고 작업했던 것은 제거 후 커밋하여서 현재 pr 로컬에서 돌릴 경우 이미지를 제외한 부분은 화면에 꽉차게 나타나게 됩니다! 참고해주세요!
- 모임 페이지에 대한 routes 주소는 임의로 설정해둔 것이니 수정해서 사용해주세요~