### PR TITLE
메인페이지 레이아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@tanstack/react-query": "^4.24.9",
+        "@types/react-slick": "^0.23.10",
         "axios": "^1.3.3",
         "emotion-reset": "^3.0.1",
         "framer-motion": "^9.0.4",
@@ -20,7 +21,9 @@
         "react-hook-form": "^7.43.1",
         "react-icons": "^4.7.1",
         "react-router-dom": "^6.8.1",
-        "recoil": "^0.7.6"
+        "react-slick": "^0.29.0",
+        "recoil": "^0.7.6",
+        "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
         "@types/node": "^18.14.0",
@@ -2360,14 +2363,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2383,11 +2384,18 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.10.tgz",
+      "integrity": "sha512-ZiqdencANDZy6sWOWJ54LDvebuXFEhDlHtXU9FFipQR2BcYU2QJxZhvJPW6YK7cocibUiNn+YvDTbt1HtCIBVA==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -3094,6 +3102,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -3350,6 +3363,11 @@
       "peerDependencies": {
         "@emotion/react": ">=11"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4894,6 +4912,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jquery": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==",
+      "peer": true
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -4949,6 +4973,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5165,6 +5197,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6048,6 +6085,22 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -6127,6 +6180,11 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -6383,6 +6441,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6408,6 +6474,11 @@
       "engines": {
         "node": ">=0.6.19"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -8752,14 +8823,12 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -8775,11 +8844,18 @@
         "@types/react": "*"
       }
     },
+    "@types/react-slick": {
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.10.tgz",
+      "integrity": "sha512-ZiqdencANDZy6sWOWJ54LDvebuXFEhDlHtXU9FFipQR2BcYU2QJxZhvJPW6YK7cocibUiNn+YvDTbt1HtCIBVA==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -9251,6 +9327,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9457,6 +9538,11 @@
       "resolved": "https://registry.npmjs.org/emotion-reset/-/emotion-reset-3.0.1.tgz",
       "integrity": "sha512-v6scW83qSu+wtxg7lX1s0+/2U4EAAGFxDQMkvXE10jhKtyuXCzy3/su5/MU9ZjXeNv6ZjxZH51WktrKosKUy9g==",
       "requires": {}
+    },
+    "enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -10594,6 +10680,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "jquery": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==",
+      "peer": true
+    },
     "js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -10636,6 +10728,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
     },
     "json5": {
       "version": "2.2.3",
@@ -10789,6 +10889,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -11392,6 +11497,18 @@
         "react-router": "6.8.1"
       }
     },
+    "react-slick": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -11438,6 +11555,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -11618,6 +11740,12 @@
         }
       }
     },
+    "slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "requires": {}
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -11634,6 +11762,11 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@tanstack/react-query": "^4.24.9",
+    "@types/react-slick": "^0.23.10",
     "axios": "^1.3.3",
     "emotion-reset": "^3.0.1",
     "framer-motion": "^9.0.4",
@@ -21,7 +22,9 @@
     "react-hook-form": "^7.43.1",
     "react-icons": "^4.7.1",
     "react-router-dom": "^6.8.1",
-    "recoil": "^0.7.6"
+    "react-slick": "^0.29.0",
+    "recoil": "^0.7.6",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@types/node": "^18.14.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,6 @@ function App() {
     <GlobalLayout className='App'>
       <Router />
       <Global styles={globalStyle} />
-      <div>
-        <h1>WuMo</h1>
-      </div>
     </GlobalLayout>
   );
 }

--- a/src/components/main/BestLouteList.tsx
+++ b/src/components/main/BestLouteList.tsx
@@ -1,0 +1,131 @@
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+import { Box, Button, Flex, Heading, Image, Text } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Slider from 'react-slick';
+
+const DUMMYDATA = [
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '졸업 기념 여행',
+    place: '부산',
+    id: '1',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '덕질 여행 가보자고',
+    place: '일본',
+    id: '2',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '갈 땐 4명이지만 올 땐 2명',
+    place: '서울',
+    id: '3',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '뉴진스 하입보이요',
+    place: '강릉',
+    id: '4',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '회사원도 여행갈 수 있어요',
+    place: '서울',
+    id: '5',
+  },
+];
+
+const BestLouteList = () => {
+  const [dragging, setDragging] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const onBeforeChange = useCallback(() => {
+    setDragging(true);
+  }, []);
+
+  const onAfterChange = useCallback(() => {
+    setDragging(false);
+  }, []);
+
+  const onMoveLoutePage = (id: string) => {
+    navigate(`/route/${id}`);
+  };
+
+  const settings = {
+    dots: false,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: false,
+    centerMode: true,
+    autoplay: true,
+    autoplaySpeed: 5000,
+    pauseOnHover: true,
+    centerPadding: '100px',
+    touchThreshold: 200,
+    beforeChange: onBeforeChange,
+    afterChange: onAfterChange,
+    adaptiveHeight: false,
+    responsive: [
+      {
+        breakpoint: 447,
+        settings: {
+          centerPadding: '50px',
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <Flex direction='row' justify='space-between' align='center' p='1.25rem 1.875rem'>
+        <Heading size='sm'>베스트 여행루트</Heading>
+        <Button size='sm'>더보기</Button>
+      </Flex>
+      <>
+        <StyledSlider {...settings}>
+          {DUMMYDATA.map((route) => (
+            <Box
+              key={route.id}
+              onClick={() => !dragging && onMoveLoutePage(route.id)}
+              outline='none'>
+              <Image src={route.image} pos='relative' w='100%' maxH='12.5rem' />
+              <Box
+                pos='absolute'
+                top='calc(50% - 1.5625rem)'
+                left='calc(50% - 6.25rem)'
+                w='12.5rem'
+                textAlign='center'>
+                <Heading size='md'>{route.name}</Heading>
+                <Text>{route.place}</Text>
+              </Box>
+            </Box>
+          ))}
+        </StyledSlider>
+      </>
+    </>
+  );
+};
+
+export default BestLouteList;
+
+const StyledSlider = styled(Slider)`
+  .slick-slide {
+    opacity: 0.8;
+    transform: scale(0.9);
+    transition: all 500ms ease;
+    display: inline-block;
+    max-height: 12.5rem;
+    padding: 0 1.25rem;
+  }
+
+  .slick-center {
+    transform: scale(1.06);
+  }
+`;

--- a/src/components/main/BestLouteList.tsx
+++ b/src/components/main/BestLouteList.tsx
@@ -7,6 +7,8 @@ import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Slider from 'react-slick';
 
+import ROUTES from '@/src/utils/routes';
+
 const DUMMYDATA = [
   {
     image: 'https://via.placeholder.com/700x500',
@@ -52,8 +54,12 @@ const BestLouteList = () => {
     setDragging(false);
   }, []);
 
-  const onMoveLoutePage = (id: string) => {
+  const onMoveRoutePage = (id: string) => {
     navigate(`/route/${id}`);
+  };
+
+  const onMoveBestRoutePage = () => {
+    navigate(ROUTES.BEST_ROUTE);
   };
 
   const settings = {
@@ -86,14 +92,16 @@ const BestLouteList = () => {
     <>
       <Flex direction='row' justify='space-between' align='center' p='1.25rem 1.875rem'>
         <Heading size='sm'>베스트 여행루트</Heading>
-        <Button size='sm'>더보기</Button>
+        <Button size='sm' onClick={onMoveBestRoutePage}>
+          더보기
+        </Button>
       </Flex>
       <>
         <StyledSlider {...settings}>
           {DUMMYDATA.map((route) => (
             <Box
               key={route.id}
-              onClick={() => !dragging && onMoveLoutePage(route.id)}
+              onClick={() => !dragging && onMoveRoutePage(route.id)}
               outline='none'>
               <Image src={route.image} pos='relative' w='100%' maxH='12.5rem' />
               <Box

--- a/src/components/main/TotalPartyNoticeList.tsx
+++ b/src/components/main/TotalPartyNoticeList.tsx
@@ -1,0 +1,13 @@
+import { Heading } from '@chakra-ui/react';
+
+const TotalPartyNoticeList = () => {
+  return (
+    <div>
+      <Heading size='sm' p='1.25rem 1.875rem'>
+        내 모임 공지
+      </Heading>
+    </div>
+  );
+};
+
+export default TotalPartyNoticeList;

--- a/src/components/main/UserPartyList.tsx
+++ b/src/components/main/UserPartyList.tsx
@@ -7,6 +7,8 @@ import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Slider from 'react-slick';
 
+import ROUTES from '@/src/utils/routes';
+
 const DUMMYDATA = [
   {
     image: 'https://via.placeholder.com/700x500',
@@ -51,6 +53,10 @@ const UserPartyList = () => {
     navigate(`/party/${id}`);
   };
 
+  const onMovePartyListPage = () => {
+    navigate(ROUTES.PARTY_LIST);
+  };
+
   const settings = {
     dots: false,
     infinite: true,
@@ -71,7 +77,9 @@ const UserPartyList = () => {
     <>
       <Flex direction='row' justify='space-between' align='center' p='1.25rem 1.875rem'>
         <Heading size='sm'>내 모임목록</Heading>
-        <Button size='sm'>전체보기</Button>
+        <Button size='sm' onClick={onMovePartyListPage}>
+          전체보기
+        </Button>
       </Flex>
       <StyledSlider {...settings}>
         {DUMMYDATA.map((party) => (

--- a/src/components/main/UserPartyList.tsx
+++ b/src/components/main/UserPartyList.tsx
@@ -1,0 +1,108 @@
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+import { Box, Button, Flex, Heading, Image } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Slider from 'react-slick';
+
+const DUMMYDATA = [
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '가보자고',
+    id: '1',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '먹부림',
+    id: '2',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '겨울바다여행레츠고',
+    id: '3',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '퇴사기념',
+    id: '4',
+  },
+  {
+    image: 'https://via.placeholder.com/700x500',
+    name: '취업기념',
+    id: '5',
+  },
+];
+
+const UserPartyList = () => {
+  const [dragging, setDragging] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const onBeforeChange = useCallback(() => {
+    setDragging(true);
+  }, []);
+
+  const onAfterChange = useCallback(() => {
+    setDragging(false);
+  }, []);
+
+  const onMovePartyPage = (id: string) => {
+    navigate(`/party/${id}`);
+  };
+
+  const settings = {
+    dots: false,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 3,
+    slidesToScroll: 1,
+    arrows: false,
+    autoplay: true,
+    autoplaySpeed: 5000,
+    pauseOnHover: true,
+    variableWidth: true,
+    touchThreshold: 200,
+    beforeChange: onBeforeChange,
+    afterChange: onAfterChange,
+    adaptiveHeight: false,
+  };
+  return (
+    <>
+      <Flex direction='row' justify='space-between' align='center' p='1.25rem 1.875rem'>
+        <Heading size='sm'>내 모임목록</Heading>
+        <Button size='sm'>전체보기</Button>
+      </Flex>
+      <StyledSlider {...settings}>
+        {DUMMYDATA.map((party) => (
+          <Box key={party.id} onClick={() => !dragging && onMovePartyPage(party.id)}>
+            <Box p='relative' w='80px' h='80px'>
+              <Image
+                src={party.image}
+                p='absolute'
+                top='0'
+                left='0'
+                h='100%'
+                w='100%'
+                objectFit='cover'
+                borderRadius='1.25rem'
+              />
+            </Box>
+            <Heading size='xs' wordBreak='break-all' textAlign='center'>
+              {party.name}
+            </Heading>
+          </Box>
+        ))}
+      </StyledSlider>
+    </>
+  );
+};
+
+export default UserPartyList;
+const StyledSlider = styled(Slider)`
+  .slick-slide {
+    margin: 0 1.25rem;
+    width: 5rem;
+    display: inline-block;
+  }
+`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { RecoilRoot } from 'recoil';
 
 import App from './App';
 
-const { Avatar, Button, Container, Heading, Tabs } = chakraTheme.components;
+const { Avatar, Button, Container, Heading, Tabs, Divider } = chakraTheme.components;
 
 const theme = extendBaseTheme({
   components: {
@@ -15,6 +15,7 @@ const theme = extendBaseTheme({
     Container,
     Heading,
     Tabs,
+    Divider,
   },
 });
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,19 @@
+import { Divider } from '@chakra-ui/react';
+
+import BestLouteList from '../components/main/BestLouteList';
+import TotalPartyNoticeList from '../components/main/TotalPartyNoticeList';
+import UserPartyList from '../components/main/UserPartyList';
+
 const MainPage = () => {
-  return <div>MainPage</div>;
+  return (
+    <>
+      <BestLouteList />
+      <Divider marginTop='40px' borderTopWidth='10px' />
+      <UserPartyList />
+      <Divider marginTop='40px' borderTopWidth='10px' />
+      <TotalPartyNoticeList />
+    </>
+  );
 };
 
 export default MainPage;

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -8,6 +8,8 @@ const ROUTES = {
   LIKE: '/like',
   PARTY_CREATE: '/party-create',
   MY_INFO: '/myinfo',
+  BEST_ROUTE: '/best-route-list',
+  PARTY_LIST: '/party-list',
 } as const;
 
 export default ROUTES;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #9

## 📖 구현 내용
- react-slick 설치
- 베스트 여행루트 섹션 캐러셀 구현
  - 루트 상세 페이지로 router연결(임시 주소)
- 내 모임 목록 섹션 캐러셀 구현
  - 파티 상세페이지로 router연결(임시 주소)
- 내 모임 공지 영역 잡기

## 🖼 구현 이미지

![메인페이지 560px](https://user-images.githubusercontent.com/107309247/220592911-7bce2be7-5392-457f-90d9-25d140273248.gif)
width 560px일 때

![메인페이지 12pro](https://user-images.githubusercontent.com/107309247/220592983-111b5463-637d-4d18-a007-3fe696eac7a5.gif)
아이폰 12 pro 화면일 때

## ✅ PR 포인트 & 궁금한 점
- 베스트 여행 루트랑 내 모임 목록에서 둘 다 캐러셀이 사용되서 재사용 가능하게 해보고 싶었는데 안의 스타일도 다르고 하다보니 마땅한 방법이 안떠올라서 일단 각각 컴포넌트로 진행했습니다! 더 고민해보고 좋은 방법이 떠오르면 리팩토링해보고 싶어요~
- 배스트 여행루트, 내 모임 목록은 각각 item을 눌렀을 때 해당 페이지로 이동하도록 router를 걸어뒀고 주소는 임시로 작성해두었습니다!
- 공지 리스트 부분은 우선순위가 후순위기도 하고 공지 탭에서 컴포넌트 먼저 구현하는 게 나을 거 같아서 영역만 잡았습니다!
- 캐러셀은 모두 5초마다 자동으로 넘어가도록 설정하였습니다.
- react-slick 설치하였으니 머지되면 `npm i` 한번씩 해주세요~