### PR TITLE
buttom sheet 모달 구현

### DIFF
--- a/src/components/base/BottomSheet.tsx
+++ b/src/components/base/BottomSheet.tsx
@@ -10,16 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 
-type BottomSheetProps = {
-  isOpen: boolean;
-  onClose: () => void;
-  modal: {
-    title: string;
-    content: JSX.Element;
-    onClick: () => void;
-    buttonTitle: string;
-  };
-};
+import { BottomSheetProps } from '@/src/types/butommSheet';
 
 const BottomSheet = ({ isOpen, onClose, modal }: BottomSheetProps) => {
   return (

--- a/src/components/base/BottomSheet.tsx
+++ b/src/components/base/BottomSheet.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 
-import { BottomSheetProps } from '@/src/types/butommSheet';
+import { BottomSheetProps } from '@/src/types/bottomSheet';
 
 const BottomSheet = ({ isOpen, onClose, modal }: BottomSheetProps) => {
   return (
@@ -49,7 +49,7 @@ const BottomSheet = ({ isOpen, onClose, modal }: BottomSheetProps) => {
                   modal.onClick && modal.onClick();
                 }}
                 borderRadius='2xl'>
-                {modal.buttonTitle}
+                {modal.buttonText}
               </Button>
             </Center>
           </ModalBody>

--- a/src/components/base/BottomSheet.tsx
+++ b/src/components/base/BottomSheet.tsx
@@ -1,0 +1,71 @@
+import {
+  Button,
+  Center,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
+import { motion } from 'framer-motion';
+
+type BottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  modal: {
+    title: string;
+    content: JSX.Element;
+    onClick: () => void;
+    buttonTitle: string;
+  };
+};
+
+const BottomSheet = ({ isOpen, onClose, modal }: BottomSheetProps) => {
+  return (
+    <>
+      <Modal isCentered onClose={onClose} isOpen={isOpen} motionPreset='slideInBottom'>
+        <ModalOverlay height='100vh' maxW='35rem' left='0' right='0' margin='0 auto' />
+        <ModalContent
+          as={motion.div}
+          position='fixed'
+          bottom='0'
+          mb='0'
+          borderRadius='1.75rem 1.75rem 0 0'
+          maxW='35rem'
+          initial={{ y: 100 }}
+          animate={{
+            y: 0,
+            transition: {
+              type: 'spring',
+              bounce: 0,
+              duration: 0.3,
+            },
+          }}>
+          <ModalHeader fontSize='2xl'>{modal.title}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Center flexDir='column' mt='6' mb='4'>
+              {modal.content}
+              <Button
+                bg='primary.red'
+                color='white'
+                size='lg'
+                w='99%'
+                marginTop='40px'
+                onClick={() => {
+                  onClose();
+                  modal.onClick && modal.onClick();
+                }}
+                borderRadius='2xl'>
+                {modal.buttonTitle}
+              </Button>
+            </Center>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/base/CustomTextarea.tsx
+++ b/src/components/base/CustomTextarea.tsx
@@ -1,0 +1,15 @@
+import { Textarea } from '@chakra-ui/react';
+
+const CustomTextarea = () => {
+  return (
+    <Textarea
+      resize='none'
+      w='99%'
+      border='1px solid lightgray'
+      rows={10}
+      borderRadius='0.625rem'
+    />
+  );
+};
+
+export default CustomTextarea;

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -18,6 +18,10 @@ const globalStyle = css`
     height: 100%;
   }
 
+  body::-webkit-scrollbar {
+    display: none;
+  }
+
   #root {
     font-family: 'Pretendard-Regular';
     height: 100%;

--- a/src/types/bottomSheet.d.ts
+++ b/src/types/bottomSheet.d.ts
@@ -5,6 +5,6 @@ export type BottomSheetProps = {
     title: string;
     content: JSX.Element;
     onClick: () => void;
-    buttonTitle: string;
+    buttonText: string;
   };
 };

--- a/src/types/butommSheet.d.ts
+++ b/src/types/butommSheet.d.ts
@@ -1,0 +1,10 @@
+export type BottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  modal: {
+    title: string;
+    content: JSX.Element;
+    onClick: () => void;
+    buttonTitle: string;
+  };
+};


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #17

## 📖 구현 내용
- buttom sheet 모달 구현
- textarea 공통 컴포넌트 구현
- body 스크롤 숨기기

## 🖼 구현 이미지

![bottomSheet](https://user-images.githubusercontent.com/107309247/221122257-5e46d418-9534-42ff-b4d8-8bbe1f5b2a88.gif)


## ✅ PR 포인트 & 궁금한 점
- 사용하는 곳에서 필요한 내용
```tsx
const { isOpen, onOpen, onClose } = useDisclosure(); //chakra modal hook
  const modalContent = {
    title: '새 피드 작성',
    content: <CustomTextarea />,
    buttonText: 'submit',
    onClick: () => {
      alert('제출 성공!');
    }, //modal 컴포넌트에 props로 넘겨줘야할 것들
  };

<Button onClick={onOpen}>모달</Button>
//modal 버튼에는 onClick 이벤트에 onOpen을 걸어줍니다.
<BottomSheet isOpen={isOpen} onClose={onClose} modal={modalContent} /> 
//BottomSheet 컴포넌트에는 isOpen과 onClose를 넘겨줍니다.
```

- 전체 스크롤이 생기면 모달 ModalOverlay width가 밀려서 기능을 유지하고 스크롤만 숨겼어요!