### PR TITLE
여행 댓글 피드 페이지 레이아웃 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,12 +8,14 @@ import {
   LikeRouteListPage,
   MainPage,
   PartyAlbumPage,
+  PartyCommentPage,
   PartyNoticePage,
   PartyPlanPage,
   PartySchedulePage,
   SignInPage,
   SignUpPage,
 } from './pages';
+import PlaceCreatePage from './pages/PlaceCreatePage';
 import ROUTES from './utils/constants/routes';
 
 const Router = () => {
@@ -31,6 +33,8 @@ const Router = () => {
             <Route path={ROUTES.PLAN} element={<PartyPlanPage />} />
             <Route path={ROUTES.ALBUM} element={<PartyAlbumPage />} />
           </Route>
+          <Route path={ROUTES.PLACE_NEW} element={<PlaceCreatePage />} />
+          <Route path={ROUTES.SCHEDULE_COMMENT} element={<PartyCommentPage />} />
         </Route>
         <Route path={ROUTES.SIGNUP} element={<SignUpPage />} />
         <Route path={ROUTES.SIGNIN} element={<SignInPage />} />

--- a/src/components/base/FloatingButton.tsx
+++ b/src/components/base/FloatingButton.tsx
@@ -1,0 +1,27 @@
+import { Box, Button } from '@chakra-ui/react';
+import { css } from '@emotion/react';
+
+import { FloatingButtonProps } from '@/types/floatingButton';
+
+const FloatingButton = ({ icon, onClick }: FloatingButtonProps) => {
+  return (
+    <Box
+      css={css`
+        direction: rtl;
+      `}>
+      <Button
+        p='0'
+        pos='fixed'
+        bottom='100px'
+        mr='0.625rem'
+        bg='primary.yellow'
+        borderRadius='50%'>
+        <Box fontSize='3xl' onClick={onClick}>
+          {icon}
+        </Box>
+      </Button>
+    </Box>
+  );
+};
+
+export default FloatingButton;

--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -8,7 +8,7 @@ const BottomNavigation = () => {
   const { pathname } = useLocation();
   return (
     <>
-      <Navigation maxW='maxWidth.mobile'>
+      <Navigation maxW='maxWidth.mobile' bg='white' zIndex='10'>
         <Flex justify='space-between'>
           {NAVIGATION_ITEM.map((item) => (
             <Link to={item.link} key={item.id}>
@@ -26,7 +26,9 @@ const BottomNavigation = () => {
           ))}
         </Flex>
       </Navigation>
-      <StyledOutlet />
+      <Box mb='5rem'>
+        <StyledOutlet />
+      </Box>
     </>
   );
 };
@@ -40,7 +42,7 @@ export const Navigation = styled(Grid)`
 `;
 
 const StyledOutlet = styled(Outlet)`
-  padding-bottom: 5rem;
+  margin-bottom: 5rem;
 `;
 
 export default BottomNavigation;

--- a/src/components/party/schedule/CommentFeedItem.tsx
+++ b/src/components/party/schedule/CommentFeedItem.tsx
@@ -1,0 +1,45 @@
+import { Avatar, Box, Button, Container, Flex, Image, Text } from '@chakra-ui/react';
+
+import { CommentTypes } from '@/types/schedule';
+import { replaceDateSlashWithDot } from '@/utils/dateTransform';
+
+const CommentFeedItem = ({
+  nickName,
+  profileImage,
+  memberRole,
+  content,
+  image,
+  createdAt,
+}: CommentTypes) => {
+  const customDate = replaceDateSlashWithDot(createdAt);
+  return (
+    <Container p='1rem' borderBottom='solid 0.125rem' borderColor='blackAlpha.200'>
+      <Flex align='center' mb='0.625rem'>
+        <Avatar src={profileImage} m='0.3125rem' />
+        <Box m='0 0.5rem'>
+          <Text fontWeight='bold' m='0.125rem 0'>
+            {nickName}
+          </Text>
+          <Text size='xs' color='blackAlpha.500'>
+            {memberRole}
+          </Text>
+        </Box>
+        <Text mt='auto' mb='0.5rem'>
+          {customDate}
+        </Text>
+        <Box ml='auto'>
+          <Button size='xs' mr='0.3125rem'>
+            수정
+          </Button>
+          <Button size='xs'>삭제</Button>
+        </Box>
+      </Flex>
+      <Box>
+        <Text p='0.625rem 0'>{content}</Text>
+        {image && <Image src={image} w='100%' m='0 auto' maxH='18.75rem' />}
+      </Box>
+    </Container>
+  );
+};
+
+export default CommentFeedItem;

--- a/src/components/party/schedule/CommentFeedTitle.tsx
+++ b/src/components/party/schedule/CommentFeedTitle.tsx
@@ -1,0 +1,41 @@
+import { AccordionButton, Button, Flex, Heading, Text } from '@chakra-ui/react';
+import { css } from '@emotion/react';
+import { MdOutlinePlace } from 'react-icons/md';
+
+import { CommentFeedTitleProps } from '@/types/schedule';
+import { replaceDateSlashWithDot } from '@/utils/dateTransform';
+import { scrollToTop } from '@/utils/scrollToTop';
+
+const CommentFeedTitle = ({ isExpanded, placeData }: CommentFeedTitleProps) => {
+  const placeVisitDate = replaceDateSlashWithDot(placeData.visitDate);
+
+  return (
+    <Flex align='center' p='0.375rem 0'>
+      <MdOutlinePlace
+        css={css`
+          width: 1.875rem;
+          height: 100%;
+        `}
+      />
+      <Flex align='baseline' onClick={scrollToTop}>
+        <Heading as='span' size='md' mr='0.25rem'>
+          {placeData.place}
+        </Heading>
+        <Text as='span'>{placeVisitDate}</Text>
+      </Flex>
+      <AccordionButton
+        as={Button}
+        p='0.625rem 0'
+        w='3.125rem'
+        h='1.875rem'
+        fontSize='sm'
+        ml='auto'
+        bg={isExpanded ? 'gray.100' : 'primary.yellow !important'}
+        borderRadius='0.9375rem'>
+        {isExpanded ? '닫기' : '지출'}
+      </AccordionButton>
+    </Flex>
+  );
+};
+
+export default CommentFeedTitle;

--- a/src/components/party/schedule/PlaceAmountField.tsx
+++ b/src/components/party/schedule/PlaceAmountField.tsx
@@ -1,0 +1,68 @@
+import {
+  AccordionPanel,
+  Button,
+  Flex,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  Text,
+} from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { MdCreditCard } from 'react-icons/md';
+
+import { AmountType } from '@/types/schedule';
+
+const PlaceAmountField = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty },
+  } = useForm<AmountType>({
+    defaultValues: {
+      amount: '', //서버에 저장된 값이 있을 경우 불러오도록 설정해야 함.
+    },
+  });
+
+  const onSubmitAmount = ({ amount }: AmountType) => {
+    if (!isDirty) return;
+    //서버 통신
+    alert(`${amount}원`);
+  };
+
+  return (
+    <div>
+      <AccordionPanel as='form' onSubmit={handleSubmit(onSubmitAmount)} p='0.5rem 0'>
+        <Flex align='center' mt='0.5rem'>
+          <Text pr='0.625rem'>사용금액</Text>
+          <InputGroup size='sm' maxW='12.5rem'>
+            <InputLeftElement
+              pointerEvents='none'
+              color='gray'
+              fontSize='1.5625rem'
+              ml='0.25rem'>
+              <MdCreditCard />
+            </InputLeftElement>
+            <Input
+              type='number'
+              borderRadius='0.9375rem'
+              placeholder='사용 금액을 입력하세요'
+              {...register('amount')}
+            />
+            <InputRightElement>원</InputRightElement>
+          </InputGroup>
+          <Button
+            type='submit'
+            variant='outline'
+            size='sm'
+            borderRadius='0.9375rem'
+            marginLeft='auto'>
+            수정
+          </Button>
+        </Flex>
+      </AccordionPanel>
+    </div>
+  );
+};
+
+export default PlaceAmountField;

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -100,7 +100,7 @@ const RouteCommentFeed = () => {
           )}
         </AccordionItem>
       </Accordion>
-      <Box mt='3.125rem' pb='5rem'>
+      <Box mt='3.125rem'>
         {COMMENTDUMMYDATA.map((comment) => (
           <CommentFeedItem key={comment.id} {...comment} />
         ))}

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -1,0 +1,114 @@
+import { Accordion, AccordionItem, Box, useDisclosure } from '@chakra-ui/react';
+import { AiOutlinePlus } from 'react-icons/ai';
+
+import BottomSheet from '../../base/BottomSheet';
+import CustomTextarea from '../../base/CustomTextarea';
+import FloatingButton from '../../base/FloatingButton';
+import CommentFeedItem from './CommentFeedItem';
+import CommentFeedTitle from './CommentFeedTitle';
+import PlaceAmountField from './PlaceAmountField';
+
+const PLACEDUMMYDATA = {
+  locations: [
+    {
+      name: '갈치구이집',
+      visitDate: '2023-02-27T06:51:55.604Z',
+    },
+  ],
+};
+
+const COMMENTDUMMYDATA = [
+  {
+    id: 0,
+    nickName: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    memberRole: '총무',
+    content: '웨이팅 3시간 미친짓이었지만 맛있었다^^',
+    image: 'https://via.placeholder.com/300',
+    createdAt: '2023-02-25T12:00:57.301Z',
+  },
+  {
+    id: 1,
+    nickName: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    memberRole: '총무',
+    content: '웨이팅 3시간 미친짓이었지만 맛있었다^^',
+    createdAt: '2023-02-25T12:00:57.301Z',
+  },
+  {
+    id: 2,
+    nickName: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    memberRole: '총무',
+    content: '웨이팅 3시간 미친짓이었지만 맛있었다^^',
+    image: 'https://via.placeholder.com/300',
+    createdAt: '2023-02-25T12:00:57.301Z',
+  },
+  {
+    id: 3,
+    nickName: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    memberRole: '총무',
+    content: '웨이팅 3시간 미친짓이었지만 맛있었다^^',
+    createdAt: '2023-02-25T12:00:57.301Z',
+  },
+  {
+    id: 4,
+    nickName: '오예스',
+    profileImage: 'https://via.placeholder.com/50',
+    memberRole: '총무',
+    content: '웨이팅 3시간 미친짓이었지만 맛있었다^^',
+    image: 'https://via.placeholder.com/300',
+    createdAt: '2023-02-25T12:00:57.301Z',
+  },
+];
+
+const modalContent = {
+  title: '새 피드 작성',
+  content: <CustomTextarea />,
+  buttonText: 'submit',
+  onClick: () => {
+    alert('제출 성공');
+  },
+};
+
+const placeData = {
+  place: PLACEDUMMYDATA.locations[0].name,
+  visitDate: PLACEDUMMYDATA.locations[0].visitDate,
+};
+
+const RouteCommentFeed = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <>
+      <Accordion allowMultiple>
+        <AccordionItem
+          p='0.625rem'
+          borderBottom='2px solid'
+          borderBottomColor='gray.100'
+          pos='fixed'
+          top='0'
+          bg='white'
+          w='100%'
+          maxW='35rem'
+          zIndex='10'>
+          {({ isExpanded }) => (
+            <>
+              <CommentFeedTitle isExpanded={isExpanded} placeData={placeData} />
+              <PlaceAmountField />
+            </>
+          )}
+        </AccordionItem>
+      </Accordion>
+      <Box mt='3.125rem' pb='5rem'>
+        {COMMENTDUMMYDATA.map((comment) => (
+          <CommentFeedItem key={comment.id} {...comment} />
+        ))}
+      </Box>
+      <FloatingButton icon={<AiOutlinePlus />} onClick={onOpen} />
+      <BottomSheet isOpen={isOpen} onClose={onClose} modal={modalContent} />
+    </>
+  );
+};
+
+export default RouteCommentFeed;

--- a/src/pages/PartyCommentPage.tsx
+++ b/src/pages/PartyCommentPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import RouteCommentFeed from '../components/party/schedule/PlaceCommentFeed';
+
+const PartyCommentPage = () => {
+  return (
+    <>
+      <RouteCommentFeed />
+    </>
+  );
+};
+
+export default PartyCommentPage;

--- a/src/pages/PlaceCreatePage.tsx
+++ b/src/pages/PlaceCreatePage.tsx
@@ -1,15 +1,11 @@
 import { Button, useDisclosure } from '@chakra-ui/react';
 
-import PlaceSearchModal from '@/components/party/place/PlaceSearchModal';
-
 const PlaceCreatePage = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { onOpen } = useDisclosure();
 
   return (
     <>
       <Button onClick={onOpen}>장소 검색</Button>
-
-      <PlaceSearchModal isOpen={isOpen} onClose={onClose} />
     </>
   );
 };

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,6 +3,7 @@ export { default as BestRouteListPage } from './BestRouteListPage';
 export { default as LikeRouteListPage } from './LikeRouteListPage';
 export { default as MainPage } from './MainPage';
 export { default as PartyAlbumPage } from './PartyAlbumPage';
+export { default as PartyCommentPage } from './PartyCommentPage';
 export { default as PartyNoticePage } from './PartyNoticePage';
 export { default as PartyPlanPage } from './PartyPlanPage';
 export { default as PartySchedulePage } from './PartySchedulePage';

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -10,10 +10,6 @@ const globalStyle = css`
     font-style: normal;
   }
 
-  html {
-    height: 100%;
-  }
-
   body {
     height: 100%;
   }

--- a/src/types/floatingButton.d.ts
+++ b/src/types/floatingButton.d.ts
@@ -1,0 +1,4 @@
+export type FloatingButtonProps = {
+  icon: JSX.Element;
+  onClick: () => void;
+};

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -1,4 +1,4 @@
-export type CommentTypes = {
+export type CommentType = {
   nickName: string;
   profileImage: string;
   memberRole: string;

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -1,0 +1,20 @@
+export type CommentTypes = {
+  nickName: string;
+  profileImage: string;
+  memberRole: string;
+  content: string;
+  image?: string;
+  createdAt: string;
+};
+
+export type CommentFeedTitleProps = {
+  isExpanded: boolean;
+  placeData: {
+    place: string;
+    visitDate: string;
+  };
+};
+
+export type AmountType = {
+  amount: string;
+};

--- a/src/utils/constants/routes.ts
+++ b/src/utils/constants/routes.ts
@@ -4,6 +4,7 @@ const ROUTES = {
   SIGNIN: '/signin',
   NOTICE: '/notice',
   SCHEDULE: '/schedule',
+  SCHEDULE_COMMENT: '/schedule-comment',
   PLAN: '/plan',
   ALBUM: '/album',
   LIKE: '/like',

--- a/src/utils/dateTransform.ts
+++ b/src/utils/dateTransform.ts
@@ -1,0 +1,3 @@
+export const replaceDateSlashWithDot = (date: string) => {
+  return date.slice(2, 10).replaceAll('-', '.');
+};

--- a/src/utils/scrollToTop.ts
+++ b/src/utils/scrollToTop.ts
@@ -1,0 +1,8 @@
+export const scrollToTop = () => {
+  if (!window.scrollY) return;
+
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #34 

## 📖 구현 내용
- 댓글 피드 페이지 레이아웃 마크업 구현
- 헤더 -> 아코디언으로 지출 버튼 클릭 시 사용금액 입력 필드 노출 
- 사용금액 입력 필드
  - 입력 없을 경우(defaultValue와 같을 경우) api 호출 안함.
- 헤더 타이틀 클릭 시 최상단으로 스크롤
- + 플로팅 버튼 클릭 시 새 피드 작성 bottomSheet 팝업
- date 포맷팅하는 uitl 함수 구현
  - 연도 뒤에서 2자리부터 날짜까지 자르기
  - 하이픈 (-) 으로 들어오는 구분점 온점(.)으로 변경 
- 하단 nav bar
  - background-color 설정이 사라져서 white로 재설정
  - zIndex 10으로 설정
  - main 부분(outlet) padding-bottom 적용이 안되서 `html {height: 100%}` 제거

## 🖼 구현 이미지

![댓글피드페이지](https://user-images.githubusercontent.com/107309247/221651681-6b1d781e-024b-40d8-adce-8958bd9976c0.gif)


## ✅ PR 포인트 & 궁금한 점
- 하단 nav bar 설정이 사라져서 재설정 추가로 했습니다!
- 버튼 스타일은 수정이 필요할 것 같아요!
- 원래 최상단으로 이동하는 플로팅 버튼을 더 넣으려고했는데 찾아보니 모바일은 플로팅 버튼이 최대한 적거나 없는 게 좋다고 해서 타이틀 클릭하면 최상단 이동으로 변경했습니다!
- 사용금액 입력 필드는 추후에 여력이 되면 포맷팅도 추가되면 좋을 것 같네요!
- develop rebase하면서 이것저것 고치고 하단 nav bar로 추가로 고치다보니 커밋이랑 파일 변경이 많아진 것 같아요! 다음부턴 줄이도록 하겠습니다 !! 