### PR TITLE
루트 타임라인 레이아웃 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
+import ScrollToTop from './components/base/ScrollToTop';
 import BottomNavigation from './components/navigation/BottomNavigation';
 import PartyInformation from './components/party/partyInformation/PartyInformation';
 import {
@@ -11,7 +12,7 @@ import {
   PartyCommentPage,
   PartyCreatePage,
   PartyListPage,
-  PartyNoticePage,
+  // PartyNoticePage,
   PartyPlanPage,
   PartySchedulePage,
   SignInPage,
@@ -22,6 +23,7 @@ import ROUTES from './utils/constants/routes';
 const Router = () => {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         <Route element={<BottomNavigation />}>
           <Route path={ROUTES.MAIN} element={<MainPage />} />
@@ -31,7 +33,7 @@ const Router = () => {
           <Route path={ROUTES.BEST_ROUTE_DETAIL} element={<BestRouteDetailPage />} />
           <Route path={ROUTES.PARTY_LIST} element={<PartyListPage />} />
           <Route element={<PartyInformation />}>
-            <Route path={ROUTES.NOTICE} element={<PartyNoticePage />} />
+            {/* <Route path={ROUTES.NOTICE} element={<PartyNoticePage />} /> */}
             <Route path={ROUTES.SCHEDULE} element={<PartySchedulePage />} />
             <Route path={ROUTES.PLAN} element={<PartyPlanPage />} />
             <Route path={ROUTES.ALBUM} element={<PartyAlbumPage />} />

--- a/src/components/base/ScrollToTop.ts
+++ b/src/components/base/ScrollToTop.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/navigation/BackNavigation.tsx
+++ b/src/components/navigation/BackNavigation.tsx
@@ -8,7 +8,7 @@ import { BackNavigationProps } from '@/types/backNavigation';
 const BackNavigation = ({ title, option }: BackNavigationProps) => {
   const navigate = useNavigate();
   return (
-    <Nav maxW='maxWidth.mobile' bg='white' zIndex='10'>
+    <Nav maxW='maxWidth.mobile' bg='white' zIndex='20'>
       <Flex justify='space-between'>
         <SpanButton onClick={() => navigate(-1)}>
           <MdKeyboardArrowLeft />

--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -8,7 +8,7 @@ const BottomNavigation = () => {
   const { pathname } = useLocation();
   return (
     <>
-      <Navigation maxW='maxWidth.mobile' bg='white' zIndex='10'>
+      <Navigation maxW='maxWidth.mobile' bg='white' zIndex='50'>
         <Flex justify='space-between'>
           {NAVIGATION_ITEM.map((item) => (
             <Link to={item.link} key={item.id}>

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -1,14 +1,17 @@
-import { Button, Container, Flex, Heading, Image, Text } from '@chakra-ui/react';
+import { Box, Button, Container, Flex, Heading, Image, Text } from '@chakra-ui/react';
 import { BsFillShareFill } from 'react-icons/bs';
 import { Outlet } from 'react-router-dom';
+
+import BackNavigation from '@/components/navigation/BackNavigation';
 
 import PartyMenuTabList from './PartyMenuTabList';
 import PartyUserList from './PartyUserList';
 
 const PartyInformation = () => {
   return (
-    <>
-      <Image src='https://via.placeholder.com/500x200' />
+    <Box>
+      <BackNavigation />
+      <Image src='https://via.placeholder.com/560x200' pt='48px' />
       <Flex justify='space-between'>
         <Container p='0.625rem' m='0'>
           <Heading size='md'>파티 명</Heading>
@@ -24,10 +27,14 @@ const PartyInformation = () => {
         </Flex>
       </Flex>
       <PartyUserList />
-      <Text margin='0.625rem'>파티 소개</Text>
+      <Text margin='0.625rem' h='3.125rem'>
+        파티 소개
+      </Text>
       <PartyMenuTabList />
-      <Outlet />
-    </>
+      <Box>
+        <Outlet />
+      </Box>
+    </Box>
   );
 };
 

--- a/src/components/party/partyInformation/PartyMenuTabList.tsx
+++ b/src/components/party/partyInformation/PartyMenuTabList.tsx
@@ -5,10 +5,6 @@ import ROUTES from '@/utils/constants/routes';
 
 const partyTab = [
   {
-    name: '공지',
-    to: ROUTES.NOTICE,
-  },
-  {
     name: '일정',
     to: ROUTES.SCHEDULE,
   },
@@ -24,7 +20,7 @@ const partyTab = [
 
 const PartyMenuTabList = () => {
   return (
-    <Tabs>
+    <Tabs pos='sticky' top='10' bg='white' zIndex='20'>
       <TabList>
         {partyTab.map((tab) => (
           <Link key={tab.name} to={tab.to} style={{ width: '100%' }}>

--- a/src/components/party/partyList/PartyListCard.tsx
+++ b/src/components/party/partyList/PartyListCard.tsx
@@ -27,7 +27,7 @@ const PartyListCard = ({
   const navigate = useNavigate();
   const handleClick = (id: number) => {
     console.log(id);
-    navigate(ROUTES.MAIN);
+    navigate(ROUTES.SCHEDULE);
   };
   return (
     <Card

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -87,7 +87,7 @@ const RouteCommentFeed = () => {
           borderBottom='2px solid'
           borderBottomColor='gray.100'
           pos='fixed'
-          top='0'
+          top='10'
           bg='white'
           w='100%'
           maxW='35rem'
@@ -100,7 +100,7 @@ const RouteCommentFeed = () => {
           )}
         </AccordionItem>
       </Accordion>
-      <Box mt='3.125rem'>
+      <Box mt='6.25rem'>
         {COMMENTDUMMYDATA.map((comment) => (
           <CommentFeedItem key={comment.id} {...comment} />
         ))}

--- a/src/components/party/schedule/RouteTimeline.tsx
+++ b/src/components/party/schedule/RouteTimeline.tsx
@@ -1,0 +1,93 @@
+import { List } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+
+import { TimeLineProps } from '@/types/schedule';
+
+import RouteTimelineItem from './RouteTimelineItem';
+
+const DUMMYDATA = {
+  likeCount: 10,
+  locations: [
+    {
+      id: 1,
+      name: '다이도코로',
+      address: '부산 수영구 남천동로108번길 27 2층 다이도코로',
+      latitude: '34.56789',
+      longitude: '123.56789',
+      image: 'https://ifh.cc/g/k1PnR2.jpg',
+      description: '가라아게 존맛',
+      visitDate: '2023-02-28T07:11:14.766Z',
+      spending: 55000,
+      category: 'meal',
+    },
+    {
+      id: 2,
+      name: '룸즈에이 서면점',
+      address: '부산 부산진구 중앙대로680번가길 9 3층',
+      latitude: '34.56789',
+      longitude: '123.56789',
+      image: 'https://ifh.cc/g/pQ78VB.jpg',
+      description: '방탈출 가보자고',
+      visitDate: '2023-02-28T07:11:14.766Z',
+      spending: 80000,
+      category: 'culture',
+    },
+    {
+      id: 3,
+      name: '럭키상회',
+      address: '부산 부산진구 중앙대로680번가길 75-1',
+      latitude: '34.56789',
+      longitude: '123.56789',
+      image: 'https://ifh.cc/g/2GSGcZ.jpg',
+      description: '부산하면 회지',
+      visitDate: '2023-02-28T07:11:14.766Z',
+      spending: 50000,
+      category: 'beer',
+    },
+    {
+      id: 4,
+      name: '해운대 스카이캡슐',
+      address: '부산 해운대구 달맞이길62번길 13',
+      latitude: '34.56789',
+      longitude: '123.56789',
+      image: 'https://ifh.cc/g/ZzdCmH.jpg',
+      description: '해운대에서 스카이캡슐 타기!',
+      visitDate: '2023-02-28T07:11:14.766Z',
+      spending: 30000,
+      category: 'sightseeing',
+    },
+  ],
+  image: 'https://via.placeholder.com/300',
+  name: '퇴사 기념 여행',
+};
+
+const RouteTimeline = ({ onClickhandler, routerButton }: TimeLineProps) => {
+  return (
+    <>
+      <StyleList>
+        {DUMMYDATA.locations.map((route) => (
+          <RouteTimelineItem
+            key={route.id}
+            {...route}
+            onClickhandler={onClickhandler}
+            routerButton={routerButton}
+          />
+        ))}
+      </StyleList>
+    </>
+  );
+};
+
+export default RouteTimeline;
+
+const StyleList = styled(List)`
+  position: relative;
+
+  &::before {
+    content: '';
+    height: 100%;
+    border: 1px solid #e0e0e0;
+    position: absolute;
+    left: 13.5%;
+  }
+`;

--- a/src/components/party/schedule/RouteTimelineItem.tsx
+++ b/src/components/party/schedule/RouteTimelineItem.tsx
@@ -1,0 +1,79 @@
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Image,
+  ListIcon,
+  ListItem,
+  Text,
+} from '@chakra-ui/react';
+import { css } from '@emotion/react';
+import dayjs from 'dayjs';
+import { MdOutlinePlace } from 'react-icons/md';
+
+import { routeListProps } from '@/types/schedule';
+import { categoryList, getImageURL } from '@/utils/constants/place';
+
+const RouteTimelineItem = ({
+  name,
+  address,
+  image,
+  visitDate,
+  spending,
+  category,
+  onClickhandler,
+  routerButton,
+}: routeListProps) => {
+  return (
+    <ListItem pt='1.875rem'>
+      <Flex justify='center'>
+        <Flex direction='column' align='center' zIndex='10'>
+          <Text fontSize='xs' bg='white'>
+            {dayjs(visitDate).format('YY.MM.DD')}
+          </Text>
+          <Text fontSize='xs' bg='white'>
+            {dayjs(visitDate).format('HH:mm')}
+          </Text>
+          <ListIcon
+            as={Image}
+            src={getImageURL(categoryList[category].imageID)}
+            bg='gray.100'
+            w='3.125rem'
+            h='3.125rem'
+            p='0.625rem'
+            m='0.375rem 0'
+            borderRadius='0.625rem'
+          />
+          <Text fontSize='xs' bg='white'>
+            {spending} 원
+          </Text>
+        </Flex>
+        <Box onClick={onClickhandler} w='70%' pos='relative' ml='1rem'>
+          <Flex align='center' justify='space-between' mb='18px'>
+            <Heading size='sm'>{name}</Heading>
+            {routerButton && (
+              <Button variant='ghost' size='xs'>
+                {routerButton}
+              </Button>
+            )}
+          </Flex>
+          <Card>
+            <Image src={image} w='100%' maxH='12.5rem' borderTopRadius='0.625rem' />
+            <Flex h='3.125rem' align='center' p='10px'>
+              <MdOutlinePlace
+                css={css`
+                  font-size: 1.625rem;
+                `}
+              />
+              <Text fontSize='xs'>{address}</Text>
+            </Flex>
+          </Card>
+        </Box>
+      </Flex>
+    </ListItem>
+  );
+};
+
+export default RouteTimelineItem;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ const {
   Avatar,
   Button,
   CloseButton,
+  Card,
   Container,
   Divider,
   FormLabel,
@@ -21,6 +22,7 @@ const {
   Modal,
   NumberInput,
   Progress,
+  List,
 } = chakraTheme.components;
 
 const theme = extendBaseTheme({
@@ -29,6 +31,7 @@ const theme = extendBaseTheme({
     Avatar,
     Button,
     CloseButton,
+    Card,
     Container,
     Divider,
     FormLabel,
@@ -39,6 +42,7 @@ const theme = extendBaseTheme({
     Modal,
     NumberInput,
     Progress,
+    List,
   },
   fonts: {
     heading: `'Pretendard-Regular', sans-serif`,

--- a/src/pages/PartyCommentPage.tsx
+++ b/src/pages/PartyCommentPage.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import BackNavigation from '@/components/navigation/BackNavigation';
 
 import RouteCommentFeed from '../components/party/schedule/PlaceCommentFeed';
 
 const PartyCommentPage = () => {
   return (
     <>
+      <BackNavigation />
       <RouteCommentFeed />
     </>
   );

--- a/src/pages/PartySchedulePage.tsx
+++ b/src/pages/PartySchedulePage.tsx
@@ -1,5 +1,22 @@
+import { MdArrowForwardIos } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+
+import RouteTimeline from '@/components/party/schedule/RouteTimeline';
+import ROUTES from '@/utils/constants/routes';
+
 const PartySchedulePage = () => {
-  return <div>PartySchedulePage</div>;
+  const navigate = useNavigate();
+  const onMoveCommentPage = () => {
+    navigate(ROUTES.SCHEDULE_COMMENT);
+  };
+  return (
+    <>
+      <RouteTimeline
+        onClickhandler={onMoveCommentPage}
+        routerButton={<MdArrowForwardIos />}
+      />
+    </>
+  );
 };
 
 export default PartySchedulePage;

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -18,3 +18,17 @@ export type CommentFeedTitleProps = {
 export type AmountType = {
   amount: string;
 };
+
+export type TimeLineProps = {
+  onClickhandler?: () => void;
+  routerButton?: JSX.Element;
+};
+
+export type routeListProps = {
+  name: string;
+  address: string;
+  image: string;
+  visitDate: string;
+  spending: number;
+  category: string;
+} & TimeLineProps;

--- a/src/utils/constants/navigationItem.ts
+++ b/src/utils/constants/navigationItem.ts
@@ -42,7 +42,7 @@ export const NAVIGATION_ITEM: NavigationItem[] = [
     name: '내 모임',
     icon: MdPeopleOutline,
     activeIcon: MdPeople,
-    link: ROUTES.NOTICE,
+    link: ROUTES.PARTY_LIST,
   },
   {
     id: '5',


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #45 

## 📖 구현 내용
- router
  - 하단 nav bar 내 모임 버튼 클릭 시 내 모임 목록 페이지로 이동
  - 내 모임 목록 card 클릭 시 해당 파티 상세 페이지로 이동
  - 해당 장소 클릭 시 해당 장소 댓글 피드 페이지로 이동
  - 공지 탭 삭제

- 기능
  - 루트 타임라인 컴포넌트 구현
    - 재사용을 위해 router이동용 버튼과 onClick 이벤트를 props로 받습니다.
    - onClick는 타임라인 카드 자체에 걸어두긴 했는데 이동가능하다고 알려주는 버튼이 필요하다고 생각해서 `>` 버튼 추가했습니다!
  - BottomNavigation과 BackNavigation  z-index 수정했습니다!
  - 댓글 피드 페이지 backNavigation 연결

## 🖼 구현 이미지

![플로우 수정](https://user-images.githubusercontent.com/107309247/222067419-f2f6cf57-6af5-4bcb-a58e-c155543bb4e8.gif)
router 수정

![루트 타임라인](https://user-images.githubusercontent.com/107309247/222067443-89f1f630-8490-443b-9f32-0004e67666af.gif)
타임라인 기능 구현

## ✅ PR 포인트 & 궁금한 점
- routerButton과 onClick 이벤트는 옵셔널로 받습니다.

- 추후 수정하고 싶은 것
  - 스크롤 했을 때 파티 이름이 상단 backNavigation의 타이틀이 되도록 하고 싶어요!
  - 댓글 피드페이지에서 backNavigation과 상호명 - 지출 버튼 타이틀을 합치고 싶네용
- props debs가 2인데 recoil로 추후에 빼는 게 좋을까요 ??
PartySchedulePage -> RouteTimeline -> RouteTimelineItem