### PR TITLE
MoreMenu 컴포넌트 구현

### DIFF
--- a/src/components/base/MoreMenu.tsx
+++ b/src/components/base/MoreMenu.tsx
@@ -1,0 +1,32 @@
+import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { MdMoreVert } from 'react-icons/md';
+
+import { menuListEventProps } from '@/types/moreMenu';
+
+const MoreMenu = ({ editEvent, removeEvent }: menuListEventProps) => {
+  return (
+    <Menu>
+      <MenuButton>
+        <MdMoreVert />
+      </MenuButton>
+      <MenuList pos='absolute' right='-8' minW='160px' zIndex='30'>
+        <MenuItem
+          fontSize='lg'
+          onClick={editEvent}
+          _focus={{ backgroundColor: 'none' }}
+          _hover={{ backgroundColor: 'gray.100' }}>
+          수정하기
+        </MenuItem>
+        <MenuItem
+          fontSize='lg'
+          color='red'
+          onClick={removeEvent}
+          _hover={{ backgroundColor: 'gray.100' }}>
+          삭제하기
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default MoreMenu;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,7 @@ const {
   NumberInput,
   Progress,
   List,
+  Menu,
 } = chakraTheme.components;
 
 const theme = extendBaseTheme({
@@ -41,6 +42,7 @@ const theme = extendBaseTheme({
     Table,
     Tabs,
     Modal,
+    Menu,
     NumberInput,
     Progress,
     List,

--- a/src/types/moreMenu.d.ts
+++ b/src/types/moreMenu.d.ts
@@ -1,0 +1,4 @@
+export type menuListEventProps = {
+  editEvent: () => void;
+  removeEvent: () => void;
+};


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #82 

## 📖 구현 내용
- moreMenu 컴포넌트 구현
  - 수정하기를 클릭했을 때와 삭제하기 클릭했을 때의 이벤트를 props로 받습니다!

사용할 때
```jsx
const menuListEvent = {
  editEvent: () => alert('수정'), //수정 이벤트
  removeEvent: () => alert('삭제'), //삭제 이벤트
}; // 이벤트 설정

<BackNavigation option={<MoreMenu {...menuListEvent} />} /> //option으로 MoreMenu 컴포넌트와 props를 설정해서 넘겨줍니다.
```
사용방법은 수정된 backNavigation에 따라 달라질 수도 있을 것 같아요~

## 🖼 구현 이미지

![moreMenu 컴포넌트](https://user-images.githubusercontent.com/107309247/222903475-432a0d8b-e187-4142-a2d9-ffa1999e4f17.gif)

## ✅ PR 포인트 & 궁금한 점
- 어떤 메뉴들어갈지 title도 props 로 받을까하다가 일단은 변경사항이 없을 것 같아서 픽스해서 진행했어요! 이후에 변경사항이 있게 된다면 타이틀도 받는 식으로 수정해야 할 것 같네요~