### PR TITLE
댓글 페이지, 후보지 페이지 moreMenu 연결

### DIFF
--- a/src/components/base/MoreMenu.tsx
+++ b/src/components/base/MoreMenu.tsx
@@ -1,9 +1,9 @@
 import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { MdMoreVert } from 'react-icons/md';
 
-import { menuListEventProps } from '@/types/moreMenu';
+import { MoreMenuListEventProps } from '@/types/moreMenu';
 
-const MoreMenu = ({ editEvent, removeEvent }: menuListEventProps) => {
+const MoreMenu = ({ onEditEvent, onRemoveEvent }: MoreMenuListEventProps) => {
   return (
     <Menu>
       <MenuButton>
@@ -12,7 +12,7 @@ const MoreMenu = ({ editEvent, removeEvent }: menuListEventProps) => {
       <MenuList pos='absolute' right='-8' minW='160px' zIndex='30'>
         <MenuItem
           fontSize='lg'
-          onClick={editEvent}
+          onClick={onEditEvent}
           _focus={{ backgroundColor: 'none' }}
           _hover={{ backgroundColor: 'gray.100' }}>
           수정하기
@@ -20,7 +20,7 @@ const MoreMenu = ({ editEvent, removeEvent }: menuListEventProps) => {
         <MenuItem
           fontSize='lg'
           color='red'
-          onClick={removeEvent}
+          onClick={onRemoveEvent}
           _hover={{ backgroundColor: 'gray.100' }}>
           삭제하기
         </MenuItem>

--- a/src/components/navigation/BackNavigation.tsx
+++ b/src/components/navigation/BackNavigation.tsx
@@ -11,10 +11,17 @@ import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 import MoreMenu from '../base/MoreMenu';
 import PartyUpdate from '../party/partyUpdate/PartyUpdate';
 
+const { SEARCH, MENU, MORE } = BACKNAVIGATION_OPTIONS;
+
 const BackNavigation = ({ title, option, moreMenuEvent }: BackNavigationProps) => {
-  const { SEARCH, MENU, MORE } = BACKNAVIGATION_OPTIONS;
   const [isShowSearch, setIsShowSearch] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const optionList = {
+    [SEARCH]: <MdSearch />,
+    [MENU]: <MdSettings />,
+    [MORE]: <MoreMenu {...moreMenuEvent} />,
+  };
 
   const onClickOption = (option: string) => {
     switch (option) {
@@ -31,7 +38,7 @@ const BackNavigation = ({ title, option, moreMenuEvent }: BackNavigationProps) =
 
   const navigate = useNavigate();
   return (
-    <Nav maxW='maxWidth.mobile' bg='white' zIndex='20' h='60px'>
+    <Nav maxW='maxWidth.mobile' bg='white' zIndex='20' h='3.75rem' userSelect='none'>
       <Flex justify='space-between'>
         <BackButton onClick={() => navigate(-1)}>
           <MdKeyboardArrowLeft />
@@ -41,20 +48,13 @@ const BackNavigation = ({ title, option, moreMenuEvent }: BackNavigationProps) =
           onClick={() => {
             if (option) onClickOption(option);
           }}>
-          {option === SEARCH ? (
-            <MdSearch />
-          ) : option === MENU ? (
-            <MdSettings />
-          ) : option === MORE ? (
-            <MoreMenu {...moreMenuEvent} />
-          ) : (
-            ''
-          )}
+          {option && optionList[option]}
         </BackButton>
       </Flex>
-      {option === SEARCH && isShowSearch ? (
+      {option === SEARCH && isShowSearch && (
         <Flex
           py='1rem'
+          bg='white'
           justifyContent='space-between'
           as={motion.div}
           initial={{ scale: 0 }}
@@ -67,8 +67,6 @@ const BackNavigation = ({ title, option, moreMenuEvent }: BackNavigationProps) =
           />
           <Button fontSize='0.875rem'>{SEARCH}</Button>
         </Flex>
-      ) : (
-        ''
       )}
       <PartyUpdate isOpen={isOpen} onClose={onClose} />
     </Nav>

--- a/src/components/navigation/BackNavigation.tsx
+++ b/src/components/navigation/BackNavigation.tsx
@@ -8,10 +8,11 @@ import { useNavigate } from 'react-router-dom';
 import { BackNavigationProps } from '@/types/backNavigation';
 import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 
+import MoreMenu from '../base/MoreMenu';
 import PartyUpdate from '../party/partyUpdate/PartyUpdate';
 
-const BackNavigation = ({ title, option }: BackNavigationProps) => {
-  const { SEARCH, MENU } = BACKNAVIGATION_OPTIONS;
+const BackNavigation = ({ title, option, moreMenuEvent }: BackNavigationProps) => {
+  const { SEARCH, MENU, MORE } = BACKNAVIGATION_OPTIONS;
   const [isShowSearch, setIsShowSearch] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -30,7 +31,7 @@ const BackNavigation = ({ title, option }: BackNavigationProps) => {
 
   const navigate = useNavigate();
   return (
-    <Nav maxW='maxWidth.mobile' bg='white' zIndex='20'>
+    <Nav maxW='maxWidth.mobile' bg='white' zIndex='20' h='60px'>
       <Flex justify='space-between'>
         <BackButton onClick={() => navigate(-1)}>
           <MdKeyboardArrowLeft />
@@ -40,7 +41,15 @@ const BackNavigation = ({ title, option }: BackNavigationProps) => {
           onClick={() => {
             if (option) onClickOption(option);
           }}>
-          {option === SEARCH ? <MdSearch /> : option === MENU ? <MdSettings /> : ''}
+          {option === SEARCH ? (
+            <MdSearch />
+          ) : option === MENU ? (
+            <MdSettings />
+          ) : option === MORE ? (
+            <MoreMenu {...moreMenuEvent} />
+          ) : (
+            ''
+          )}
         </BackButton>
       </Flex>
       {option === SEARCH && isShowSearch ? (

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -52,7 +52,7 @@ const PartyInformation = () => {
   return (
     <Box>
       <BackNavigation option={BACKNAVIGATION_OPTIONS.MENU} />
-      <Image src='https://via.placeholder.com/560x200' pt='4.75rem' />
+      <Image src='https://via.placeholder.com/560x200' pt='3.75rem' />
       <Flex justify='space-between'>
         <Container p='0.625rem' m='0'>
           <Heading size='md'>{DUMMYDATA.name}</Heading>

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -6,6 +6,7 @@ import CustomTextarea from '@/components/base/CustomTextarea';
 import FloatingButton from '@/components/base/FloatingButton';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import useScrollEvent from '@/hooks/useScrollEvent';
+import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 import { getCategoryImageURL } from '@/utils/constants/place';
 import { scrollToTop } from '@/utils/scrollToTop';
 
@@ -85,6 +86,11 @@ const modalContent = {
   },
 };
 
+const moreMenuEvent = {
+  onEditEvent: () => alert('수정'),
+  onRemoveEvent: () => alert('삭제'),
+};
+
 const placeData = {
   place: PLACEDUMMYDATA.locations[0].name,
   visitDate: PLACEDUMMYDATA.locations[0].visitDate,
@@ -98,7 +104,11 @@ const RouteCommentFeed = () => {
   );
   return (
     <>
-      <BackNavigation title={scrollActive ? navigationTitle : ''} />
+      <BackNavigation
+        title={scrollActive ? navigationTitle : ''}
+        option={BACKNAVIGATION_OPTIONS.MORE}
+        moreMenuEvent={moreMenuEvent}
+      />
       <Box>
         <Img
           src={PLACEDUMMYDATA.locations[0].image}

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonGroup, Flex, Heading, Image } from '@chakra-ui/react';
+import { Box, Flex, Heading, Image } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -7,8 +7,14 @@ import CommentForm from '@/components/place/CommentForm';
 import PlaceInfoTable from '@/components/place/PlaceInfoTable';
 import PlacePreviewMap from '@/components/placeCreate/search/PlacePreviewMap';
 import useMapScript from '@/hooks/useMapScript';
+import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 import { getCategoryImageURL, PLACES_DUMMY_DATA } from '@/utils/constants/place';
 import { scrollToTop } from '@/utils/scrollToTop';
+
+const moreMenuEvent = {
+  onEditEvent: () => alert('수정'),
+  onRemoveEvent: () => alert('삭제'),
+};
 
 const PlacePage = () => {
   const { id } = useParams();
@@ -26,7 +32,10 @@ const PlacePage = () => {
 
   return (
     <>
-      <BackNavigation />
+      <BackNavigation
+        option={BACKNAVIGATION_OPTIONS.MORE}
+        moreMenuEvent={moreMenuEvent}
+      />
       <Box height='2xs' marginTop='12'>
         <Image src={data.image} height='3xs' width='full' objectFit='cover' />
         <Image
@@ -37,10 +46,6 @@ const PlacePage = () => {
         />
       </Box>
       <Flex direction='column' padding='5' paddingTop='0' gap='2'>
-        <ButtonGroup gap='1' variant='outline' size='sm' justifyContent='flex-end'>
-          <Button borderRadius='2xl'>수정</Button>
-          <Button borderRadius='2xl'>삭제</Button>
-        </ButtonGroup>
         <Heading as='h2' size='lg' paddingTop='3' paddingBottom='3'>
           {data.name}
         </Heading>

--- a/src/types/backNavigation.d.ts
+++ b/src/types/backNavigation.d.ts
@@ -1,4 +1,5 @@
 export type BackNavigationProps = {
   title?: string | JSX.Element;
   option?: string;
+  moreMenuEvent?: MoreMenuListEventProps;
 };

--- a/src/types/moreMenu.d.ts
+++ b/src/types/moreMenu.d.ts
@@ -1,4 +1,4 @@
-export type menuListEventProps = {
-  editEvent: () => void;
-  removeEvent: () => void;
+export type MoreMenuListEventProps = {
+  onEditEvent: () => void;
+  onRemoveEvent: () => void;
 };

--- a/src/utils/constants/navigationItem.ts
+++ b/src/utils/constants/navigationItem.ts
@@ -56,4 +56,5 @@ export const NAVIGATION_ITEM: NavigationItem[] = [
 export const BACKNAVIGATION_OPTIONS = {
   SEARCH: '검색',
   MENU: '메뉴',
+  MORE: '더보기',
 };


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #88 

## 📖 구현 내용
- 댓글 피드 페이지 moreMenu 연결
- 후보지 상세 페이지 moreMenu 연결

- BackNavigation
  - MoreMenu 컴포넌트 연결하면서 props로 받아야하는 내용이 있어서 backNavigation props로 받도록 해두었습니다! 

- moreMenuEvent Props
  - 현재 더보기 메뉴를 사용하는 페이지가 댓글 페이지랑 후보지 페이지밖에 없을 것 같아서 각 해당 컴포넌트에 `moreMenuEvent`라는 객체를 만들어두었습니다! 여기에 원하는 수정, 삭제 로직을 추가해서 사용하면 됩니당! 

--- 
+) 베스트 루트 페이지에서 검색 버튼 눌렀을 때 간헐적으로 드래그되는 현상 수정
BackNavigation 기본 로직 변경 없이 삼항연산자 중첩으로 사용되던 부분만 수정했어요!

## 🖼 구현 이미지

![더보기 메뉴 추가](https://user-images.githubusercontent.com/107309247/222920710-12513f2c-0bec-4d31-bd03-889b00c9e1eb.gif)


## ✅ PR 포인트 & 궁금한 점
- MoreMenu로 넘겨줘야할 props 값을 BackNavigation props로 받고 MoreMenu에게 넘겨주고 있는데 리코일을 사용하는 게 나을까요??👀