### PR TITLE
확인 모달 레이아웃 구현

### DIFF
--- a/src/components/base/ConfirmModal.tsx
+++ b/src/components/base/ConfirmModal.tsx
@@ -9,20 +9,7 @@ import {
   ModalOverlay,
 } from '@chakra-ui/react';
 
-type ConfirmModalProps = {
-  isOpen: boolean;
-  hasCloseButton?: boolean;
-  closeModalHandler: () => void;
-  body: JSX.Element;
-  buttonText: {
-    left?: string;
-    right?: string;
-  };
-  clickButtonHandler: {
-    left?: () => void;
-    right?: () => void;
-  };
-};
+import { ConfirmModalProps } from '@/types/confirmModal';
 
 const ConfirmModal = ({
   isOpen,

--- a/src/components/base/ConfirmModal.tsx
+++ b/src/components/base/ConfirmModal.tsx
@@ -1,0 +1,72 @@
+import {
+  Button,
+  ButtonGroup,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
+} from '@chakra-ui/react';
+
+type ConfirmModalProps = {
+  isOpen: boolean;
+  hasCloseButton?: boolean;
+  closeModalHandler: () => void;
+  body: JSX.Element;
+  buttonText: {
+    left?: string;
+    right?: string;
+  };
+  clickButtonHandler: {
+    left?: () => void;
+    right?: () => void;
+  };
+};
+
+const ConfirmModal = ({
+  isOpen,
+  hasCloseButton = false,
+  closeModalHandler,
+  body,
+  buttonText,
+  clickButtonHandler,
+}: ConfirmModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={closeModalHandler} isCentered>
+      <ModalOverlay />
+      <ModalContent w='90%' pt='8' pb='5' borderRadius='3xl'>
+        {hasCloseButton && <ModalCloseButton />}
+        <ModalBody fontSize='lg' pt='4'>
+          {body}
+        </ModalBody>
+        <ModalFooter justifyContent='center'>
+          <ButtonGroup gap='8' mt='4'>
+            {buttonText.left && (
+              <Button
+                backgroundColor='gray'
+                color='white'
+                size='lg'
+                p='1.5rem 2.5rem'
+                onClick={clickButtonHandler?.left || closeModalHandler}>
+                {buttonText.left}
+              </Button>
+            )}
+            {buttonText.right && (
+              <Button
+                backgroundColor='primary.red'
+                color='white'
+                size='lg'
+                p='1rem 2rem'
+                onClick={clickButtonHandler?.right}>
+                {buttonText.right}
+              </Button>
+            )}
+          </ButtonGroup>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/base/ConfirmModal.tsx
+++ b/src/components/base/ConfirmModal.tsx
@@ -44,7 +44,7 @@ const ConfirmModal = ({
                 backgroundColor='primary.red'
                 color='white'
                 size='lg'
-                p='1rem 2rem'
+                p='1.5rem 2.5rem'
                 onClick={clickButtonHandler?.primary}>
                 {buttonText.primary}
               </Button>

--- a/src/components/base/ConfirmModal.tsx
+++ b/src/components/base/ConfirmModal.tsx
@@ -29,24 +29,24 @@ const ConfirmModal = ({
         </ModalBody>
         <ModalFooter justifyContent='center'>
           <ButtonGroup gap='8' mt='4'>
-            {buttonText.left && (
+            {buttonText.secondary && (
               <Button
                 backgroundColor='gray'
                 color='white'
                 size='lg'
                 p='1.5rem 2.5rem'
-                onClick={clickButtonHandler?.left || closeModalHandler}>
-                {buttonText.left}
+                onClick={clickButtonHandler?.secondary || closeModalHandler}>
+                {buttonText.secondary}
               </Button>
             )}
-            {buttonText.right && (
+            {buttonText.primary && (
               <Button
                 backgroundColor='primary.red'
                 color='white'
                 size='lg'
                 p='1rem 2rem'
-                onClick={clickButtonHandler?.right}>
-                {buttonText.right}
+                onClick={clickButtonHandler?.primary}>
+                {buttonText.primary}
               </Button>
             )}
           </ButtonGroup>

--- a/src/pages/PartyPlanPage.tsx
+++ b/src/pages/PartyPlanPage.tsx
@@ -39,8 +39,8 @@ const PartyPlanPage = () => {
             <Text>이 후보지를 일정을 추가할까요?</Text>
           </Box>
         }
-        buttonText={{ left: '수정', right: '추가' }}
-        clickButtonHandler={{ right: () => console.log('추가 완료') }}
+        buttonText={{ secondary: '수정', primary: '추가' }}
+        clickButtonHandler={{ primary: () => console.log('추가 완료') }}
       />
     </>
   );

--- a/src/pages/PartyPlanPage.tsx
+++ b/src/pages/PartyPlanPage.tsx
@@ -1,8 +1,7 @@
-import { useDisclosure } from '@chakra-ui/react';
+import { Box, Button, Text, useDisclosure } from '@chakra-ui/react';
 import { useEffect } from 'react';
 
-import PlaceList from '@/components/party/partyPlan/PlanPlaceList';
-import PlaceCreateModal from '@/components/placeCreate/PlaceCreateModal';
+import ConfirmModal from '@/components/base/ConfirmModal';
 import PlacePreviewMap from '@/components/placeCreate/search/PlacePreviewMap';
 import useMapScript from '@/hooks/useMapScript';
 import { PLACES_DUMMY_DATA } from '@/utils/constants/place';
@@ -27,8 +26,22 @@ const PartyPlanPage = () => {
         mapMarkers={PLACES_DUMMY_DATA}
         draggable
       />
-      <PlaceList places={PLACES_DUMMY_DATA} openModalHandler={onOpen} />
-      <PlaceCreateModal isOpen={isOpen} closeModalHandler={onClose} />
+      <Button onClick={onOpen}>모달 테스트</Button>
+      {/* <PlaceList places={PLACES_DUMMY_DATA} openModalHandler={onOpen} />
+      <PlaceCreateModal isOpen={isOpen} closeModalHandler={onClose} /> */}
+      <ConfirmModal
+        isOpen={isOpen}
+        closeModalHandler={onClose}
+        body={
+          <Box textAlign='center'>
+            <Text>장소: 정통집</Text>
+            <Text>날짜: 2023년 3월 5일 오후 6시</Text>
+            <Text>이 후보지를 일정을 추가할까요?</Text>
+          </Box>
+        }
+        buttonText={{ left: '수정', right: '추가' }}
+        clickButtonHandler={{ right: () => console.log('추가 완료') }}
+      />
     </>
   );
 };

--- a/src/types/confirmModal.d.ts
+++ b/src/types/confirmModal.d.ts
@@ -1,0 +1,14 @@
+export type ConfirmModalProps = {
+  isOpen: boolean;
+  hasCloseButton?: boolean;
+  closeModalHandler: () => void;
+  body: JSX.Element;
+  buttonText: {
+    left?: string;
+    right?: string;
+  };
+  clickButtonHandler: {
+    left?: () => void;
+    right?: () => void;
+  };
+};

--- a/src/types/confirmModal.d.ts
+++ b/src/types/confirmModal.d.ts
@@ -4,11 +4,11 @@ export type ConfirmModalProps = {
   closeModalHandler: () => void;
   body: JSX.Element;
   buttonText: {
-    left?: string;
-    right?: string;
+    secondary?: string;
+    primary?: string;
   };
   clickButtonHandler: {
-    left?: () => void;
-    right?: () => void;
+    secondary?: () => void;
+    primary?: () => void;
   };
 };


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #66

## 📖 구현 내용
- 확인 모달 레이아웃 구현
  - 후보지를 계획에 추가할 때 확인, 방명록 삭제 확인 등에 쓰일 예정 

## 🖼 구현 이미지
<img width="294" alt="스크린샷 2023-03-05 오전 7 36 57" src="https://user-images.githubusercontent.com/63575891/222931641-a479c7fc-de5f-46ec-9d1e-b1c7798645eb.png">


## ✅ PR 포인트 & 궁금한 점
- 제 작업 부분에서 직전 PR과 develop 브랜치 코드가 많이 달라서 일단 임시로 레이아웃만 구현했습니다! 추후 수정 예정