### PR TITLE
지도 마커 아이콘 및 인포윈도우 추가

### DIFF
--- a/src/components/place/create/search/PlacePreviewMap.tsx
+++ b/src/components/place/create/search/PlacePreviewMap.tsx
@@ -15,7 +15,7 @@ const PlacePreviewMap = ({
   draggable = false,
   mapMarkers,
 }: PlacePreviewMapProps) => {
-  const [selectedMarker, setSelectedMarker] = useState<number>();
+  const [selectedMarker, setSelectedMarker] = useState<number | null>();
 
   return (
     <Map
@@ -42,7 +42,7 @@ const PlacePreviewMap = ({
                 height: 40,
               },
             }}
-            onClick={() => setSelectedMarker(id)}>
+            onClick={() => setSelectedMarker(id === selectedMarker ? null : id)}>
             {selectedMarker === id && (
               <Link to={`/place/${id}`}>
                 <Box

--- a/src/components/place/create/search/PlacePreviewMap.tsx
+++ b/src/components/place/create/search/PlacePreviewMap.tsx
@@ -1,6 +1,10 @@
+import { Box } from '@chakra-ui/react';
+import { useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import { Link } from 'react-router-dom';
 
 import { PlacePreviewMapProps } from '@/types/place';
+import { getGitEmoji } from '@/utils/constants/emoji';
 
 const PlacePreviewMap = ({
   latitude,
@@ -11,6 +15,8 @@ const PlacePreviewMap = ({
   draggable = false,
   mapMarkers,
 }: PlacePreviewMapProps) => {
+  const [selectedMarker, setSelectedMarker] = useState<number>();
+
   return (
     <Map
       center={{
@@ -25,8 +31,35 @@ const PlacePreviewMap = ({
         height,
       }}>
       {mapMarkers ? (
-        mapMarkers.map(({ id, latitude, longitude }) => (
-          <MapMarker key={id} position={{ lat: latitude, lng: longitude }} />
+        mapMarkers.map(({ id, name, latitude, longitude, category }) => (
+          <MapMarker
+            position={{ lat: latitude, lng: longitude }}
+            key={id}
+            image={{
+              src: getGitEmoji(category), // TODO: 좀 더 눈에 띄는 마커로 개선
+              size: {
+                width: 40,
+                height: 40,
+              },
+            }}
+            onClick={() => setSelectedMarker(id)}>
+            {selectedMarker === id && (
+              <Link to={`/place/${id}`}>
+                <Box
+                  display='inline-block'
+                  width='150px'
+                  height='43px'
+                  padding='0.7rem'
+                  whiteSpace='nowrap'
+                  overflow='hidden'
+                  fontWeight='bold'
+                  textOverflow='ellipsis'
+                  textAlign='center'>
+                  {name}
+                </Box>
+              </Link>
+            )}
+          </MapMarker>
         ))
       ) : (
         <MapMarker position={{ lat: latitude, lng: longitude }} />

--- a/src/pages/PartyPlanPage.tsx
+++ b/src/pages/PartyPlanPage.tsx
@@ -16,6 +16,7 @@ const PartyPlanPage = () => {
     // });
   }, [script]);
 
+  // TODO: 등록한 후보지가 없을 때 처리
   return (
     <>
       <PlacePreviewMap

--- a/src/types/place.d.ts
+++ b/src/types/place.d.ts
@@ -50,7 +50,10 @@ export type Place = {
   routeId?: number;
 };
 
-export type PlaceMarker = Pick<Place, 'id' | 'latitude' | 'longitude' | 'category'>;
+export type PlaceMarker = Pick<
+  Place,
+  'id' | 'name' | 'latitude' | 'longitude' | 'category'
+>;
 
 export type PlaceInformationType =
   | 'visitDate'


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #70

## 📖 구현 내용
- 마커 아이콘 카테고리 이미지 적용
- 마커 인포윈도우 추가
- 마커 클릭 시 해당 후보지의 상세페이지로 이동

## 🖼 구현 이미지

<img width="50%" src="https://user-images.githubusercontent.com/63575891/223116694-26b74d56-2613-4bdc-9302-68ac054329a2.mov"/>


## ✅ PR 포인트 & 궁금한 점
- 카카오 공식 api를 그대로 적용하면 커스텀이 훨씬 쉬울텐데 현재 사용하는 대체 라이브러리에서는 내용 정도만 커스텀할 수 있어서 예쁘지 않네요.. 누르면 상세페이지로 넘어가는 걸 보여주고 싶은데 화살표 넣으니까 이름이 너무 적게 보여서 일단 제외했습니다. 후보지 관련 API 연동 후 개선해보려고 합니다!
- 마커 아이콘도 가시성이 좋지 않아서 핀 모양 아이콘과 함께 쓰고 싶은데 인포윈도우와 마찬가지로 커스텀이 쉽지 않아서 직접 이미지 파일(svg)로 만들어 대체하고자 합니다. 현재 사용하는 카테고리 이미지도 이미지 링크보다는 파일 자체를 public에서 관리하는 게 좀 더 안전할 것 같은데 추후 논의해보면 좋을 것 같습니다~