### PR TITLE
댓글 생성 이미지 등록 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,9 +7,6 @@ type AxiosInterceptorChildrenType = {
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
   withCredentials: true,
 });
 
@@ -86,7 +83,12 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
           config.headers.Authorization = null;
           return config;
         }
-
+        config.headers = config.headers ?? {};
+        if (config.data instanceof FormData) {
+          config.headers['Content-Type'] = 'multipart/form-data';
+        } else {
+          config.headers['Content-Type'] = 'application/json';
+        }
         if (config.headers && tokens) {
           const { accessToken } = JSON.parse(tokens);
           config.headers.Authorization = `Bearer ${accessToken}`;

--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -1,0 +1,13 @@
+import axiosInstance from './api';
+
+export const createImage = async (image: FormData) => {
+  try {
+    const response = await axiosInstance.post(`/api/v1/images`, image);
+
+    if (response) return response.data.imageUrl;
+  } catch (error) {
+    console.error(error);
+
+    throw error;
+  }
+};

--- a/src/api/schedules.ts
+++ b/src/api/schedules.ts
@@ -1,9 +1,11 @@
+import { CreateCommentBody } from '@/types/schedule';
+
 import axiosInstance from './api';
 
-export const fetchScheduleList = async (routeId: number, isPublic: boolean) => {
+export const fetchScheduleList = async (partyId: number, isPublic: boolean) => {
   try {
     const response = await axiosInstance.get(
-      `api/v1/routes/${11}?path=${isPublic ? 1 : 0}`
+      `api/v1/routes/${partyId}?path=${isPublic ? 1 : 0}`
     );
     if (response) return response.data;
   } catch (error) {
@@ -14,8 +16,20 @@ export const fetchScheduleList = async (routeId: number, isPublic: boolean) => {
 export const fetchLocationCommentList = async (cursorId: number, locationId: number) => {
   try {
     const response = await axiosInstance.get(
-      `api/v1/party-route-comments?cursorId=${cursorId}&pageSize=5&locationId=${locationId}`
+      `api/v1/party-route-comments?cursorId=${cursorId}&pageSize=1000&locationId=${locationId}`
     );
+    if (response) return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const createLocationComment = async (body: CreateCommentBody) => {
+  try {
+    const response = await axiosInstance.post(`/api/v1/party-route-comments`, {
+      ...body,
+    });
+
     if (response) return response.data;
   } catch (error) {
     console.error(error);

--- a/src/components/base/BottomSheet.tsx
+++ b/src/components/base/BottomSheet.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Center,
   Modal,
   ModalBody,
@@ -46,24 +45,7 @@ const BottomSheet = ({ isOpen, onClose, modal }: BottomSheetProps) => {
           <ModalHeader fontSize='2xl'>{modal.title}</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Center flexDir='column' mb={modal.buttonText ? '4' : '20'}>
-              {modal.content}
-              {modal.buttonText && (
-                <Button
-                  bg='primary.red'
-                  color='white'
-                  size='lg'
-                  w='99%'
-                  marginTop='40px'
-                  onClick={() => {
-                    onClose();
-                    modal.onClick && modal.onClick();
-                  }}
-                  borderRadius='2xl'>
-                  {modal.buttonText}
-                </Button>
-              )}
-            </Center>
+            <Center flexDir='column'>{modal.content}</Center>
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/src/components/base/BottomSheetButton.tsx
+++ b/src/components/base/BottomSheetButton.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@chakra-ui/react';
+
+type BottomSheetButtonProps = {
+  isSubmitting: boolean;
+  isDisabled: boolean;
+  buttonText: string;
+  onClick?: () => void;
+};
+
+const BottomSheetButton = ({
+  isSubmitting,
+  isDisabled,
+  buttonText,
+  onClick,
+  ...props
+}: BottomSheetButtonProps) => {
+  return (
+    <Button
+      type='submit'
+      isLoading={isSubmitting}
+      isDisabled={isDisabled}
+      bg='primary.red'
+      color='white'
+      size='lg'
+      w='99%'
+      marginTop='40px'
+      borderRadius='2xl'
+      onClick={onClick}
+      _hover={{ backgroundColor: 'none' }}
+      {...props}>
+      {buttonText}
+    </Button>
+  );
+};
+
+export default BottomSheetButton;

--- a/src/components/base/CustomTextarea.tsx
+++ b/src/components/base/CustomTextarea.tsx
@@ -1,14 +1,29 @@
 import { Textarea } from '@chakra-ui/react';
+import { InputHTMLAttributes } from 'react';
+import { Control, FieldPath, FieldValues, useController } from 'react-hook-form';
 
-const CustomTextarea = () => {
+interface UserInputProps<T extends FieldValues>
+  extends InputHTMLAttributes<HTMLInputElement> {
+  control: Control<T>;
+  name: FieldPath<T>;
+}
+
+const CustomTextarea = <T extends FieldValues>({ name, control }: UserInputProps<T>) => {
+  const { field } = useController({
+    name,
+    control,
+  });
+
   return (
     <Textarea
+      id={name}
       resize='none'
       w='99%'
       border='1px solid lightgray'
       p='0.625rem'
       rows={10}
       borderRadius='0.625rem'
+      {...field}
     />
   );
 };

--- a/src/components/party/schedule/CommentCreate.tsx
+++ b/src/components/party/schedule/CommentCreate.tsx
@@ -1,0 +1,89 @@
+import { Box, useDisclosure } from '@chakra-ui/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { AiOutlinePlus } from 'react-icons/ai';
+import { useLocation } from 'react-router-dom';
+
+import { createImage } from '@/api/image';
+import { createLocationComment } from '@/api/schedules';
+import BottomSheet from '@/components/base/BottomSheet';
+import BottomSheetButton from '@/components/base/BottomSheetButton';
+import CustomTextarea from '@/components/base/CustomTextarea';
+import FloatingButton from '@/components/base/FloatingButton';
+import { ModalType } from '@/types/bottomSheet';
+import { CommentCreateType, CreateCommentBody } from '@/types/schedule';
+
+import CommentImageInput from './CommentImageInput';
+
+const CommentCreate = () => {
+  const queryClient = useQueryClient();
+  const { state } = useLocation();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    control,
+    handleSubmit,
+    resetField,
+    formState: { isSubmitting, isDirty },
+  } = useForm<CommentCreateType>({
+    defaultValues: {
+      content: '',
+      image: null,
+    },
+  });
+
+  const { mutateAsync: createImageUrl, reset: imageReset } = useMutation(createImage);
+  const { mutateAsync: createComment } = useMutation(createLocationComment);
+
+  const onSubmitImageFile = async (image: File | null) => {
+    if (!image) return null;
+    const formData = new FormData();
+    formData.append('image', image);
+    const imageUrl = await createImageUrl(formData);
+    return imageUrl;
+  };
+
+  const onSubmitNewComment = async ({ content, image }: CommentCreateType) => {
+    const imageUrl = await onSubmitImageFile(image);
+
+    const commentBody: CreateCommentBody = {
+      content,
+      image: imageUrl,
+      partyId: 11, //이후 router state로 받아올 예정
+      locationId: state.locationId,
+    };
+
+    await createComment(commentBody, {
+      onSuccess: () => {
+        onClose();
+        return queryClient.invalidateQueries(['commentList']);
+      },
+    });
+
+    imageReset();
+    resetField('content');
+  };
+
+  const modalContent: ModalType = {
+    title: '새 피드 작성',
+    content: (
+      <Box as='form' mb='4' w='100%' onSubmit={handleSubmit(onSubmitNewComment)}>
+        <CustomTextarea name='content' control={control} />
+        <CommentImageInput name='image' control={control} />
+        <BottomSheetButton
+          isSubmitting={isSubmitting}
+          isDisabled={!isDirty}
+          buttonText='Submit'
+        />
+      </Box>
+    ),
+  };
+
+  return (
+    <div>
+      <FloatingButton icon={<AiOutlinePlus />} onClick={onOpen} />
+      <BottomSheet isOpen={isOpen} onClose={onClose} modal={modalContent} />
+    </div>
+  );
+};
+
+export default CommentCreate;

--- a/src/components/party/schedule/CommentImageInput.tsx
+++ b/src/components/party/schedule/CommentImageInput.tsx
@@ -1,0 +1,99 @@
+import { Button, Flex, Img, Input } from '@chakra-ui/react';
+import { ChangeEvent, InputHTMLAttributes, useRef, useState } from 'react';
+import { Control, FieldPath, FieldValues, useController } from 'react-hook-form';
+
+interface ImageProps<T extends FieldValues>
+  extends InputHTMLAttributes<HTMLInputElement> {
+  control: Control<T>;
+  name: FieldPath<T>;
+}
+
+const CommentImageInput = <T extends FieldValues>({ name, control }: ImageProps<T>) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [fileName, setFileName] = useState('');
+  const [value, setValue] = useState('');
+  const [imageBase64, setImageBase64] = useState<string>('');
+  const { field } = useController({
+    name,
+    control,
+  });
+
+  const encodeFileToBase64 = (fileBlob: File) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(fileBlob);
+    return new Promise((resolve) => {
+      reader.onload = () => {
+        const result = reader.result;
+        if (!result || typeof result !== 'string') return;
+        setImageBase64(result);
+        resolve(Promise);
+      };
+    });
+  };
+
+  const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setFileName(file.name);
+      encodeFileToBase64(file);
+    }
+    e.target.value = '';
+  };
+
+  const onFileDelete = () => {
+    setImageBase64('');
+    setFileName('');
+    field.onChange(null);
+  };
+
+  return (
+    <Flex flexDirection='column' align='center'>
+      <Flex
+        w='100%'
+        align='center'
+        justify='space-between'
+        p='10px'
+        onClick={() => inputRef.current?.click()}>
+        <Input
+          placeholder='사진을 추가하세요'
+          defaultValue={fileName}
+          flex='1'
+          mr='1.25rem'
+          border='none'
+          borderBottom='1px solid gray'
+          borderRadius='none'
+        />
+        <Button size='sm'>사진 추가+</Button>
+        <Input
+          type='file'
+          hidden
+          {...field}
+          value={value}
+          ref={inputRef}
+          onChange={(e) => {
+            field.onChange(e.target.files?.[0]);
+            onFileChange(e);
+            setValue(e.target.value);
+          }}
+        />
+      </Flex>
+      {imageBase64 && (
+        <Flex pos='relative' mt='0.625rem' justify='center'>
+          <Button
+            onClick={onFileDelete}
+            size='sm'
+            colorScheme='blackAlpha'
+            pos='absolute'
+            borderRadius='50%'
+            top='-4'
+            right='-4'>
+            x
+          </Button>
+          <Img w='7.5rem' h='7.5rem' src={imageBase64} />
+        </Flex>
+      )}
+    </Flex>
+  );
+};
+
+export default CommentImageInput;

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -1,12 +1,9 @@
-import { Box, Img, useDisclosure } from '@chakra-ui/react';
+import { Box, Img } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
-import { AiOutlinePlus } from 'react-icons/ai';
 import { useLocation } from 'react-router-dom';
 
 import { fetchLocationCommentList, fetchScheduleList } from '@/api/schedules';
-import BottomSheet from '@/components/base/BottomSheet';
-import CustomTextarea from '@/components/base/CustomTextarea';
-import FloatingButton from '@/components/base/FloatingButton';
+import Loading from '@/components/base/Loading';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import useScrollEvent from '@/hooks/useScrollEvent';
 import { CommentListType, ScheduleLocationType, ScheduleType } from '@/types/schedule';
@@ -14,18 +11,10 @@ import { getGitEmoji } from '@/utils/constants/emoji';
 import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 import { scrollToTop } from '@/utils/scrollToTop';
 
+import CommentCreate from './CommentCreate';
 import CommentFeedItem from './CommentFeedItem';
 import CommentFeedTitle from './CommentFeedTitle';
 import PlaceAmountField from './PlaceAmountField';
-
-const modalContent = {
-  title: '새 피드 작성',
-  content: <CustomTextarea />,
-  buttonText: 'submit',
-  onClick: () => {
-    alert('제출 성공');
-  },
-};
 
 const moreMenuEvent = {
   onEditEvent: () => alert('수정'),
@@ -33,7 +22,6 @@ const moreMenuEvent = {
 };
 
 const RouteCommentFeed = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
   const { scrollActive } = useScrollEvent(300);
   const { state } = useLocation();
 
@@ -49,11 +37,16 @@ const RouteCommentFeed = () => {
     data: scheduleList,
     isLoading: scheduleLoading,
     isError: scheduleError,
-  } = useQuery<ScheduleType>(['scheduleList'], () => fetchScheduleList(1, false), {
+  } = useQuery<ScheduleType>(['scheduleList'], () => fetchScheduleList(11, false), {
     staleTime: 10000,
   });
 
-  if (commentLoading || scheduleLoading) return <></>;
+  if (commentLoading || scheduleLoading)
+    return (
+      <>
+        <Loading />
+      </>
+    );
   if (commentError || scheduleError) return <></>;
 
   const pickCurrentLocation = (locations: ScheduleLocationType[], locationId: number) => {
@@ -109,8 +102,7 @@ const RouteCommentFeed = () => {
             <CommentFeedItem key={comment.id} {...comment} />
           ))}
         </Box>
-        <FloatingButton icon={<AiOutlinePlus />} onClick={onOpen} />
-        <BottomSheet isOpen={isOpen} onClose={onClose} modal={modalContent} />
+        <CommentCreate />
       </Box>
     </>
   );

--- a/src/components/party/schedule/RouteTimeline.tsx
+++ b/src/components/party/schedule/RouteTimeline.tsx
@@ -3,29 +3,33 @@ import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchScheduleList } from '@/api/schedules';
+import Loading from '@/components/base/Loading';
 import { ScheduleType, TimeLineProps } from '@/types/schedule';
 
 import RouteTimelineItem from './RouteTimelineItem';
 
 const RouteTimeline = ({ onClickHandler, routerButton, isPublic }: TimeLineProps) => {
-  const { data: scheduleList, status } = useQuery<ScheduleType>(
-    ['scheduleList'],
-    () => fetchScheduleList(1, isPublic),
-    {
-      staleTime: 10000,
-    }
-  );
+  const {
+    data: scheduleList,
+    isLoading,
+    isError,
+  } = useQuery<ScheduleType>(['scheduleList'], () => fetchScheduleList(11, isPublic), {
+    staleTime: 10000,
+  });
 
-  if (status === 'error') return <></>;
-  if (status === 'loading') return <></>;
-
+  if (isLoading)
+    return (
+      <>
+        <Loading />
+      </>
+    );
+  if (isError) return <></>;
   return (
     <StyleList>
       {scheduleList.locations.map((route) => (
         <RouteTimelineItem
           key={route.id}
           {...route}
-          routeId={scheduleList.id}
           onClickHandler={onClickHandler}
           routerButton={routerButton}
         />

--- a/src/components/party/schedule/RouteTimelineItem.tsx
+++ b/src/components/party/schedule/RouteTimelineItem.tsx
@@ -25,7 +25,6 @@ const RouteTimelineItem = ({
   spending,
   category,
   id,
-  routeId,
   onClickHandler,
   routerButton,
 }: routeListProps) => {
@@ -53,7 +52,7 @@ const RouteTimelineItem = ({
             {getPriceText(spending)}
           </Text>
         </Flex>
-        <Box onClick={() => onClickHandler(id, routeId)} w='70%' pos='relative' ml='1rem'>
+        <Box onClick={() => onClickHandler(id)} w='70%' pos='relative' ml='1rem'>
           <Flex align='center' justify='space-between' mb='1.125rem'>
             <Heading size='sm'>{name}</Heading>
             {routerButton && (

--- a/src/components/profile/profileEdit/ProfileEditForm.tsx
+++ b/src/components/profile/profileEdit/ProfileEditForm.tsx
@@ -91,7 +91,7 @@ const ProfileEditForm = () => {
 
   const modalContent = {
     content: (
-      <Stack w='100%' spacing='4'>
+      <Stack w='100%' spacing='4' mb='20'>
         <Button onClick={handleFileChoose}>이미지 가져오기</Button>
         <Button onClick={handleDefaultImage}>기본이미지로 변경</Button>
       </Stack>

--- a/src/pages/PartyCommentPage.tsx
+++ b/src/pages/PartyCommentPage.tsx
@@ -1,4 +1,4 @@
-import RouteCommentFeed from '../components/party/schedule/PlaceCommentFeed';
+import RouteCommentFeed from '@/components/party/schedule/PlaceCommentFeed';
 
 const PartyCommentPage = () => {
   return (

--- a/src/types/bottomSheet.d.ts
+++ b/src/types/bottomSheet.d.ts
@@ -1,10 +1,10 @@
 export type BottomSheetProps = {
   isOpen: boolean;
   onClose: () => void;
-  modal: {
-    title?: string;
-    content: JSX.Element;
-    onClick?: () => void;
-    buttonText?: string;
-  };
+  modal: ModalType;
+};
+
+export type ModalType = {
+  title?: string;
+  content: JSX.Element;
 };

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -56,3 +56,15 @@ export type routeListProps = {
   spending: number;
   category: string;
 } & Pick<TimeLineProps, 'onClickHandler', 'routerButton'>;
+
+export type CreateCommentBody = {
+  content: string;
+  image?: string;
+  partyId: number;
+  locationId: number;
+};
+
+export type CommentCreateType = {
+  content: string;
+  image: File | null;
+};


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #107 

## 📖 구현 내용
- 댓글 생성 컴포넌트 구현
- 이미지 생성 컴포넌트 구현
- 댓글 생성 api 연결
- 이미지 생성 api 연결
- 헤더 content-type에 폼데이터 들어올 수 있도록 설정

## 🖼 구현 이미지

![댓글 작성](https://user-images.githubusercontent.com/107309247/223755525-49b1b731-b449-449b-bc57-59b32cb87f9c.gif)

## ✅ PR 포인트 & 궁금한 점
- 글 & 사진, 글만 ,사진만 다 작성 가능하고 하나라도 입력하지 않았을 시 submit 버튼이 클릭 되지 않아요!
- 현재 글을 작성하다가 x버튼을 눌러서 모달을 닫고 페이지 이동 없이 다시 열면 수정 중이던 글이 남아있어요! 페이지 이동 시에는 사라지는데 모달을 닫으면 바로 내용을 비우는 게 좋을까요? 
  - 모달 닫는 처리를 chakra ui 훅을 써서 한다면 어떻게 해야 할 지 고민해봐야 할 것 같아요..👀