### PR TITLE
후보지 사용금액 갱신 api 연결

### DIFF
--- a/src/api/schedules.ts
+++ b/src/api/schedules.ts
@@ -1,4 +1,4 @@
-import { CreateCommentBody } from '@/types/schedule';
+import { ChangeAmountType, CreateCommentBody } from '@/types/schedule';
 
 import axiosInstance from './api';
 
@@ -32,6 +32,16 @@ export const createLocationComment = async (body: CreateCommentBody) => {
     });
 
     if (response) return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const patchChangeAmount = async (body: ChangeAmountType) => {
+  try {
+    await axiosInstance.patch(`/locations/spending`, {
+      ...body,
+    });
   } catch (error) {
     console.error(error);
   }

--- a/src/components/party/schedule/PlaceAmountField.tsx
+++ b/src/components/party/schedule/PlaceAmountField.tsx
@@ -8,26 +8,35 @@ import {
   InputRightElement,
   Text,
 } from '@chakra-ui/react';
+import { useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { MdCreditCard } from 'react-icons/md';
+import { useLocation } from 'react-router-dom';
 
-import { AmountType } from '@/types/schedule';
+import { patchChangeAmount } from '@/api/schedules';
+import { AmountType, ChangeAmountType } from '@/types/schedule';
 
-const PlaceAmountField = () => {
+const PlaceAmountField = ({ spending }: { spending: number }) => {
+  const { mutate: changeAmount } = useMutation(patchChangeAmount);
+  const { state } = useLocation();
   const {
     register,
     handleSubmit,
     formState: { isDirty },
   } = useForm<AmountType>({
     defaultValues: {
-      amount: '', //서버에 저장된 값이 있을 경우 불러오도록 설정해야 함.
+      amount: spending,
     },
   });
 
   const onSubmitAmount = ({ amount }: AmountType) => {
     if (!isDirty) return;
-    //서버 통신
-    alert(`${amount}원`);
+    const amountBody: ChangeAmountType = {
+      locationId: state.locationId,
+      spending: Number(amount),
+    };
+    changeAmount(amountBody);
+    alert(`${amount}원으로 변경되었습니다.`);
   };
 
   return (

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -95,7 +95,7 @@ const RouteCommentFeed = () => {
           pos='relative'
           top='-18'>
           <CommentFeedTitle placeData={placeData} />
-          <PlaceAmountField />
+          <PlaceAmountField spending={currentLocation.spending} />
         </Box>
         <Box pos='relative' top='-6'>
           {commentList.partyRouteComments.map((comment) => (

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -22,7 +22,11 @@ export type CommentFeedTitleProps = {
 };
 
 export type AmountType = {
-  amount: string;
+  amount: number;
+};
+export type ChangeAmountType = {
+  locationId: number;
+  spending: number;
 };
 
 export type TimeLineProps = {


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #132 

## 📖 구현 내용
- 후보지 사용금액 갱신

## 🖼 구현 이미지

![사용 금액 갱신](https://user-images.githubusercontent.com/107309247/224230618-4106a694-8a91-406b-ba2a-be2630bd061a.gif)

## ✅ PR 포인트 & 궁금한 점 