### PR TITLE
루트 삭제 api 연결

### DIFF
--- a/src/api/schedules.ts
+++ b/src/api/schedules.ts
@@ -18,7 +18,7 @@ export const fetchScheduleList = async (partyId: number, isPublic: boolean) => {
 export const fetchLocationCommentList = async (cursorId: number, locationId: number) => {
   try {
     const response = await axiosInstance.get(
-      `/party-route-comments?cursorId=${cursorId}&pageSize=1000&locationId=${locationId}`
+      `/party-route-comments?cursorId=&pageSize=1000&locationId=${locationId}`
     );
     if (response) return response.data;
   } catch (error) {

--- a/src/components/main/BestRouteList.tsx
+++ b/src/components/main/BestRouteList.tsx
@@ -90,8 +90,9 @@ const BestRouteList = () => {
             <Box
               key={route.routeId}
               onClick={() => !dragging && onMoveRoutePage(route.routeId)}
-              outline='none'>
-              <Image src={route.image} pos='relative' w='100%' maxH='12.5rem' />
+              outline='none'
+              h='180px'>
+              <Image src={route.image} pos='relative' w='100%' maxH='12.5rem' h='100%' />
               <Box
                 pos='absolute'
                 top='calc(50% - 1.125rem)'

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -18,6 +18,7 @@ import {
   fetchPartyInformation,
   fetchPartyMembers,
 } from '@/api/party';
+import Loading from '@/components/base/Loading';
 import Toast from '@/components/base/toast/Toast';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import useScrollEvent from '@/hooks/useScrollEvent';
@@ -47,7 +48,7 @@ const PartyInformation = () => {
     data: partyInformation,
     isLoading: partyInformationLoading,
     isError: partyInformationError,
-  } = useQuery<PartyInformationType>(['partyInformation'], () =>
+  } = useQuery<PartyInformationType>(['partyInformation', partyId], () =>
     fetchPartyInformation(Number(partyId))
   );
 
@@ -55,8 +56,9 @@ const PartyInformation = () => {
     data: partyUserList,
     isLoading: partyUserListLoading,
     isError: partyUserListError,
-  } = useQuery<{ members: PartyMemberProps[]; lastID: number }>(['partyUserList'], () =>
-    fetchPartyMembers(Number(partyId))
+  } = useQuery<{ members: PartyMemberProps[]; lastID: number }>(
+    ['partyUserList', partyId],
+    () => fetchPartyMembers(Number(partyId))
   );
 
   const { mutateAsync: createInvitationCode } = useMutation(createPartyInvitation, {
@@ -76,7 +78,12 @@ const PartyInformation = () => {
     },
   });
 
-  if (partyInformationLoading || partyUserListLoading) return <></>;
+  if (partyInformationLoading || partyUserListLoading)
+    return (
+      <>
+        <Loading />
+      </>
+    );
   if (partyInformationError || partyUserListError) return <></>;
 
   const copyPartyInvitationCode = async (url: string) => {

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -118,7 +118,7 @@ const PartyInformation = () => {
         mt='3.75rem'
         h='200px'
         w='100%'
-        objectFit='none'
+        objectFit='cover'
       />
       <Flex justify='space-between'>
         <Container p='0.625rem' m='0'>

--- a/src/components/party/partyInformation/PartyUserList.tsx
+++ b/src/components/party/partyInformation/PartyUserList.tsx
@@ -11,8 +11,9 @@ const PartyUserList = () => {
     data: partyUserList,
     isLoading,
     isError,
-  } = useQuery<{ members: PartyMemberProps[]; lastID: number }>(['partyUserList'], () =>
-    fetchPartyMembers(Number(partyId))
+  } = useQuery<{ members: PartyMemberProps[]; lastID: number }>(
+    ['partyUserList', partyId],
+    () => fetchPartyMembers(Number(partyId))
   );
 
   if (isLoading) return <></>;

--- a/src/components/party/schedule/PlaceCommentFeed.tsx
+++ b/src/components/party/schedule/PlaceCommentFeed.tsx
@@ -1,8 +1,10 @@
-import { Box, Img } from '@chakra-ui/react';
-import { useQuery } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
+import { Box, Img, Text, useDisclosure } from '@chakra-ui/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
+import { deletePlaceFromRoute } from '@/api/place';
 import { fetchLocationCommentList, fetchScheduleList } from '@/api/schedules';
+import ConfirmModal from '@/components/base/ConfirmModal';
 import Loading from '@/components/base/Loading';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import useScrollEvent from '@/hooks/useScrollEvent';
@@ -16,15 +18,19 @@ import CommentFeedItem from './CommentFeedItem';
 import CommentFeedTitle from './CommentFeedTitle';
 import PlaceAmountField from './PlaceAmountField';
 
-const moreMenuEvent = {
-  onEditEvent: () => alert('수정'),
-  onRemoveEvent: () => alert('삭제'),
-};
-
 const RouteCommentFeed = () => {
   const { scrollActive } = useScrollEvent(300);
   const { state } = useLocation();
+  const { partyId } = useParams();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { isOpen, onClose, onOpen } = useDisclosure();
 
+  const { mutateAsync: deleteRoute } = useMutation(deletePlaceFromRoute, {
+    onSuccess: () => {
+      return queryClient.invalidateQueries(['scheduleList']);
+    },
+  });
   const {
     data: commentList,
     isLoading: commentLoading,
@@ -37,9 +43,13 @@ const RouteCommentFeed = () => {
     data: scheduleList,
     isLoading: scheduleLoading,
     isError: scheduleError,
-  } = useQuery<ScheduleType>(['scheduleList'], () => fetchScheduleList(11, false), {
-    staleTime: 10000,
-  });
+  } = useQuery<ScheduleType>(
+    ['scheduleList'],
+    () => fetchScheduleList(Number(partyId), false),
+    {
+      staleTime: 10000,
+    }
+  );
 
   if (commentLoading || scheduleLoading)
     return (
@@ -49,6 +59,11 @@ const RouteCommentFeed = () => {
     );
   if (commentError || scheduleError) return <></>;
 
+  const moreMenuEvent = {
+    onEditEvent: () => alert('수정'),
+    onRemoveEvent: () => onOpen(),
+  };
+
   const pickCurrentLocation = (locations: ScheduleLocationType[], locationId: number) => {
     return locations.filter((location) => location.id === locationId);
   };
@@ -57,6 +72,8 @@ const RouteCommentFeed = () => {
     scheduleList.locations,
     state.locationId
   )[0];
+
+  if (!currentLocation) return <></>;
 
   const placeData = {
     place: currentLocation.name,
@@ -104,6 +121,21 @@ const RouteCommentFeed = () => {
         </Box>
         <CommentCreate />
       </Box>
+      <ConfirmModal
+        isOpen={isOpen}
+        closeModalHandler={onClose}
+        body={<Text> &quot;{currentLocation.name}&quot; 일정을 취소 하시겠습니까?</Text>}
+        clickButtonHandler={{
+          primary: async () => {
+            await deleteRoute(state.locationId);
+            navigate(`/party/${partyId}`);
+          },
+        }}
+        buttonText={{
+          secondary: '취소',
+          primary: '삭제',
+        }}
+      />
     </>
   );
 };

--- a/src/components/party/schedule/RouteReleaseChange.tsx
+++ b/src/components/party/schedule/RouteReleaseChange.tsx
@@ -32,6 +32,12 @@ const RouteReleaseChange = ({
   const queryClient = useQueryClient();
   const { mutate: changeReleased } = useMutation(patchChangRouteReleased);
 
+  const { register, getValues, reset } = useForm({
+    defaultValues: {
+      routeName: '',
+    },
+  });
+
   const {
     data: partyInformation,
     isLoading,
@@ -40,6 +46,11 @@ const RouteReleaseChange = ({
     ['partyInformation'],
     () => fetchPartyInformation(Number(partyId)),
     {
+      onSuccess: (data) => {
+        reset({
+          routeName: data.name,
+        });
+      },
       staleTime: 5000,
     }
   );
@@ -51,12 +62,6 @@ const RouteReleaseChange = ({
       </>
     );
   if (isError) return <></>;
-
-  const { register, getValues } = useForm({
-    defaultValues: {
-      routeName: partyInformation?.name,
-    },
-  });
 
   const onRouteReleased = () => {
     if (scheduleList.isPublic) {

--- a/src/components/party/schedule/RouteTimeline.tsx
+++ b/src/components/party/schedule/RouteTimeline.tsx
@@ -16,15 +16,12 @@ const RouteTimeline = ({ onClickHandler, routerButton, isPublic }: TimeLineProps
   const {
     data: scheduleList,
     isLoading,
+    isFetching,
     isError,
-  } = useQuery<ScheduleType>(
-    ['scheduleList'],
-    () => fetchScheduleList(Number(partyId), isPublic),
-    {
-      staleTime: 10000,
-    }
+  } = useQuery<ScheduleType>(['scheduleList', partyId], () =>
+    fetchScheduleList(Number(partyId), isPublic)
   );
-  if (isLoading)
+  if (isLoading || isFetching)
     return (
       <>
         <Loading />


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #144 

## 📖 구현 내용
- 일정에서 루트 삭제하는 api 연결(유리님이 다 연결해두신 작업이라 덕분에 편하게 작업했습니다👍)
- 파티리스트에서 파티 이동할 때 이전데이터 남아서 깜빡이는 현상 수정
- 메인 베스트 루트 슬라이드 크기에 맞게 늘어나도록 설정

## 🖼 구현 이미지

![일정에서 장소 삭제](https://user-images.githubusercontent.com/107309247/224503094-028155ac-0349-46da-81cf-81edefcdb2fb.gif)

## ✅ PR 포인트 & 궁금한 점
- 파티 수정은 후보지 수정이랑 연결될 것 같아서 후보지 수정작업되면 연결하겠습니다!(넘겨주는 데이터가 복잡해지게 되면 없애버릴 수도,,,👀)