### PR TITLE
api 에러 처리

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,3 +1,6 @@
+import axios from 'axios';
+
+import Toast from '@/components/base/toast/Toast';
 import { UserEditProps } from '@/types/user';
 import { SignInProps, SignProps } from '@/types/userSign';
 
@@ -17,7 +20,23 @@ export const signIn = async (values: SignInProps) => {
     const response = await axiosInstance.post('/members/login', values);
     return response.data;
   } catch (error) {
-    console.error(error);
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 500) {
+        return Toast.show({
+          title: '로그인에 실패하였습니다.',
+          message: error.response.data.message,
+          type: 'warning',
+        });
+      }
+      if (error.response?.status === 400) {
+        return Toast.show({
+          title: '로그인에 실패하였습니다.',
+          message: '존재하지 않는 Email입니다.',
+          type: 'warning',
+        });
+      }
+    }
+    return console.error(error);
   }
 };
 
@@ -25,7 +44,11 @@ export const signUp = async (values: SignProps) => {
   try {
     await axiosInstance.post('/members/signup', values);
   } catch (error) {
-    console.error(error);
+    return Toast.show({
+      title: '회원가입 중 오류가 발생하였습니다.',
+      message: '잠시 후 다시 시도해주세요.',
+      type: 'error',
+    });
   }
 };
 
@@ -33,7 +56,7 @@ export const fetchCheckEmail = async (target: string) => {
   await axiosInstance.get(`/members/check-email?email=${target}`);
 };
 
-export const fetchNickname = async (target: string) => {
+export const fetchCheckNickname = async (target: string) => {
   await axiosInstance.get(`/members/check-nickname?nickname=${target}`);
 };
 
@@ -56,9 +79,32 @@ export const patchMyProfile = async (fields: UserEditProps) => {
 };
 
 export const sendEmailCertificationCode = async (target: string) => {
-  await axiosInstance.get(`/members/send-code?address=${target}`);
+  try {
+    await axiosInstance.get(`/members/send-code?address=${target}`);
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      return Toast.show({
+        title: '인증 메일 전송을 실패하였습니다.',
+        message: '잠시 후 다시 시도해주세요.',
+        type: 'error',
+      });
+    }
+  }
 };
 
 export const checkEmailCertificaitonCode = async (email: string, code: string) => {
-  await axiosInstance.get(`/members/check-code?address=${email}&code=${code}`);
+  try {
+    await axiosInstance.get(`/members/check-code?address=${email}&code=${code}`);
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 400) {
+        return Toast.show({
+          title: '이메일 인증에 실패하였습니다.',
+          message: error.response.data.message,
+          type: 'warning',
+        });
+      }
+    }
+    return console.error(error);
+  }
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -74,7 +74,13 @@ export const patchMyProfile = async (fields: UserEditProps) => {
     const response = axiosInstance.patch('/members/me', fields);
     return response;
   } catch (error) {
-    console.error(error);
+    if (axios.isAxiosError(error)) {
+      return Toast.show({
+        title: '프로필 수정을 실패하였습니다.',
+        message: '잠시 후 다시 시도해주세요.',
+        type: 'error',
+      });
+    }
   }
 };
 

--- a/src/components/base/ControlledInput.tsx
+++ b/src/components/base/ControlledInput.tsx
@@ -45,9 +45,7 @@ const ControlledInput = <T extends FieldValues>({
           {...field}
         />
         <InputRightElement>
-          {fieldState.isDirty && (
-            <MdCancel cursor='pointer' onClick={() => resetField(name)} />
-          )}
+          {field.value && <MdCancel cursor='pointer' onClick={() => resetField(name)} />}
         </InputRightElement>
       </InputGroup>
       <Box height={7}>

--- a/src/components/party/partyList/PartyListCard.tsx
+++ b/src/components/party/partyList/PartyListCard.tsx
@@ -45,7 +45,7 @@ const PartyListCard = ({
           objectFit='cover'
           borderRadius='2'
           maxW={{ base: '160px', sm: '200px' }}
-          src={coverImage}
+          src={coverImage ? coverImage : '/logo-lg.svg'}
           alt='Caffe Latte'
         />
 

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -15,11 +15,11 @@ const UserProfile = () => {
   } = useQuery<UserProps>(['myProfileInfo'], () => fetchMyProfileInfo());
 
   const toProfileEdit = () => {
-    navigate(ROUTES.PROFILE_EDIT);
+    navigate(ROUTES.PROFILE_EDIT, { replace: true });
   };
 
   const toLanding = () => {
-    navigate(ROUTES.LANDING);
+    navigate(ROUTES.LANDING, { replace: true });
   };
 
   const handleLogout = async () => {

--- a/src/components/profile/profileEdit/ProfileEditForm.tsx
+++ b/src/components/profile/profileEdit/ProfileEditForm.tsx
@@ -35,8 +35,8 @@ const ProfileEditForm = () => {
     control,
     handleSubmit,
     resetField,
-    reset,
-    formState: { isSubmitting },
+    setValue,
+    formState: { isSubmitting, isDirty },
   } = useForm<UserEditProps>({
     defaultValues: {
       nickname: '',
@@ -52,11 +52,10 @@ const ProfileEditForm = () => {
     isError,
   } = useQuery<UserEditProps>(['myProfileInfo'], () => fetchMyProfileInfo(), {
     onSuccess(data) {
+      if (isDirty) return;
       setOldImage(data.profileImage);
-      reset({
-        nickname: data.nickname,
-        profileImage: data.profileImage,
-      });
+      setValue('nickname', data.nickname);
+      setValue('profileImage', data.profileImage);
     },
   });
 

--- a/src/components/profile/profileEdit/ProfileEditForm.tsx
+++ b/src/components/profile/profileEdit/ProfileEditForm.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Center,
   Container,
+  Flex,
   Input,
   Stack,
   useDisclosure,
@@ -16,13 +17,14 @@ import { MdCameraAlt } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
 import { createImage, deleteImage } from '@/api/image';
-import { fetchMyProfileInfo, patchMyProfile } from '@/api/user';
+import { fetchCheckNickname, fetchMyProfileInfo, patchMyProfile } from '@/api/user';
 import BottomSheet from '@/components/base/BottomSheet';
 import ControlledInput from '@/components/base/ControlledInput';
 import Loading from '@/components/base/Loading';
 import SubmitButton from '@/components/base/SubmitButton';
 import { ImageData } from '@/types/place';
 import { UserEditProps } from '@/types/user';
+import { FORM_ERROR_MESSAGES } from '@/utils/constants/messages';
 import ROUTES from '@/utils/constants/routes';
 import { userEditSchema } from '@/utils/schema';
 
@@ -36,6 +38,9 @@ const ProfileEditForm = () => {
     handleSubmit,
     resetField,
     setValue,
+    trigger,
+    getValues,
+    setError,
     formState: { isSubmitting, isDirty },
   } = useForm<UserEditProps>({
     defaultValues: {
@@ -66,6 +71,7 @@ const ProfileEditForm = () => {
     imageBase64: oldImage,
     imageFile: null,
   });
+  const [checkNickname, setCheckNickname] = useState(false);
 
   if (isError) return <></>;
   if (isLoading)
@@ -84,6 +90,8 @@ const ProfileEditForm = () => {
   };
 
   const onSubmit = async (fields: UserEditProps) => {
+    if (!checkNickname)
+      return setError('nickname', { message: FORM_ERROR_MESSAGES.DUPLICATE });
     if (oldImage === null && myProfileInfo.profileImage !== null) {
       await deleteImage(myProfileInfo.profileImage);
     }
@@ -94,8 +102,23 @@ const ProfileEditForm = () => {
       fields.profileImage = imageUrl;
     }
     fields.id = myProfileInfo.id;
+    console.log(fields);
     await patchMyProfile(fields);
-    navigate(ROUTES.PROFILE);
+    navigate(ROUTES.PROFILE, { replace: true });
+  };
+
+  const handleCheckNickname = async () => {
+    const checkBefore = await trigger('nickname');
+    const target = getValues('nickname');
+    if (!checkBefore) return;
+
+    try {
+      await fetchCheckNickname(target);
+      setCheckNickname(true);
+    } catch (error) {
+      setCheckNickname(false);
+      setError('nickname', { message: FORM_ERROR_MESSAGES.NICKNAME_DUPLICATED });
+    }
   };
 
   const handleFileChoose = () => {
@@ -169,7 +192,16 @@ const ProfileEditForm = () => {
           onChange={handleFileChange}
         />
       </Center>
-      <ControlledInput name='nickname' control={control} resetField={resetField} />
+      <Flex justify='space-between'>
+        <ControlledInput name='nickname' control={control} resetField={resetField} />
+        <Button
+          mt={7}
+          size='sm'
+          onClick={handleCheckNickname}
+          colorScheme={checkNickname ? 'green' : 'red'}>
+          중복 확인
+        </Button>
+      </Flex>
       <SubmitButton isSubmitting={isSubmitting} mt='24' width='100%' colorScheme='orange'>
         프로필 수정
       </SubmitButton>

--- a/src/components/signIn/SignInForm.tsx
+++ b/src/components/signIn/SignInForm.tsx
@@ -35,7 +35,7 @@ const SignInForm = () => {
         accessToken,
         refreshToken,
       });
-      navigate(ROUTES.MAIN);
+      navigate(ROUTES.MAIN, { replace: true });
     } catch (error) {
       console.error(error);
     }

--- a/src/components/signUp/SignUpForm.tsx
+++ b/src/components/signUp/SignUpForm.tsx
@@ -26,7 +26,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   checkEmailCertificaitonCode,
   fetchCheckEmail,
-  fetchNickname,
+  fetchCheckNickname,
   sendEmailCertificationCode,
   signUp,
 } from '@/api/user';
@@ -73,7 +73,7 @@ const SignUpForm = () => {
       return setError('nickname', { message: FORM_ERROR_MESSAGES.DUPLICATE });
 
     await signUp(values);
-    navigate(ROUTES.SIGNIN);
+    navigate(ROUTES.SIGNIN, { replace: true });
   };
 
   const handleCheckEmail = async () => {
@@ -97,7 +97,7 @@ const SignUpForm = () => {
     if (!checkBefore) return;
 
     try {
-      await fetchNickname(target);
+      await fetchCheckNickname(target);
       setCheckNickname(true);
     } catch (error) {
       setCheckNickname(false);

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -2,7 +2,6 @@ import { Box, Flex } from '@chakra-ui/react';
 
 import LargeLogo from '@/components/base/LargeLogo';
 import BackNavigation from '@/components/navigation/BackNavigation';
-import FindUserInfo from '@/components/signIn/FindUserInfo';
 import SignInForm from '@/components/signIn/SignInForm';
 import ToSignUp from '@/components/signIn/ToSignUp';
 
@@ -15,7 +14,6 @@ const SignInPage = () => {
           <LargeLogo src='/logo-lg.svg' />
           <SignInForm />
           <ToSignUp />
-          <FindUserInfo />
         </Box>
       </Flex>
     </Box>


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #164 

## 📖 구현 내용
- 토스트 활용한 로그인, 회원가입 에러처리
- 프로필 수정시 닉네임 중복확인 기능 추가
- 각 페이지 이동 replace true 처리
- 파티리스트 카드 기본이미지 추가

## 🖼 구현 이미지

https://user-images.githubusercontent.com/82329983/224653918-fac9858f-8de6-4b22-bd69-a3fda04e40aa.mov


https://user-images.githubusercontent.com/82329983/224653943-2ebac8fb-3556-4e3b-b071-12e8c9518e9f.mov



## ✅ PR 포인트 & 궁금한 점
- 토스트로만 에러처리를 진행해보았습니다.