### PR TITLE
이미지 로딩 중일 때 스켈레톤 적용

### DIFF
--- a/public/skeleton.svg
+++ b/public/skeleton.svg
@@ -1,0 +1,3 @@
+<svg width="250" height="250" viewBox="0 0 250 250" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="250" height="250" fill="#D9D9D9"/>
+</svg>

--- a/src/components/main/BestRouteListItem.tsx
+++ b/src/components/main/BestRouteListItem.tsx
@@ -36,7 +36,7 @@ const BestRouteListItem = ({
         />
         <Image
           fallbackSrc='/logo.svg'
-          src={image ? image : './logo.svg'}
+          src={image ? image : '/logo.svg'}
           w='100%'
           maxH='12.5rem'
           h='100%'

--- a/src/components/main/BestRouteListPreview.tsx
+++ b/src/components/main/BestRouteListPreview.tsx
@@ -23,17 +23,12 @@ const BestRouteListPreview = () => {
     data: BestRouteList,
     isLoading,
     isError,
-  } = useQuery<BestRouteListType>(
-    ['BestRouteList'],
-    () => fetchBestRouteList(parameter),
-    {
-      staleTime: 10000,
-    }
-  );
+  } = useQuery<BestRouteListType>(['BestRouteList'], () => fetchBestRouteList(parameter));
 
   const parameter = {
     pageSize: 5,
     sortType: 'LIKES',
+    searchWord: '',
   };
 
   const onMoveBestRoutePage = () => {

--- a/src/components/main/UserPartyList.tsx
+++ b/src/components/main/UserPartyList.tsx
@@ -48,13 +48,12 @@ const UserPartyList = () => {
 
   const settings = {
     dots: false,
-    infinite: myPartyList.party.length >= 4,
+    infinite: false,
     speed: 500,
-    slidesToShow: 1,
+    slidesToShow: 3,
     slidesToScroll: 1,
     arrows: false,
-    autoplay: myPartyList.party.length >= 4,
-    autoplaySpeed: 5000,
+    autoplay: false,
     pauseOnHover: true,
     variableWidth: true,
     touchThreshold: 200,
@@ -118,5 +117,9 @@ const StyledSlider = styled(Slider)`
     width: 5rem;
     display: inline-block;
     padding-bottom: 2rem;
+  }
+
+  .slick-track {
+    margin: 0;
   }
 `;

--- a/src/components/party/create/PartyNameModal.tsx
+++ b/src/components/party/create/PartyNameModal.tsx
@@ -124,7 +124,12 @@ const PartyNameModal = () => {
           />
           {imageUrl !== '' ? (
             <Flex flexDirection='column' alignItems='center'>
-              <Image fallbackSrc='./logo.svg' src={imageUrl} boxSize='200px' alt={name} />
+              <Image
+                fallbackSrc='/skeleton.svg'
+                src={imageUrl}
+                boxSize='200px'
+                alt={name}
+              />
               <HStack pt='1rem'>
                 <Button h='10' onClick={onClickImageUpload}>
                   이미지 변경

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -103,7 +103,7 @@ const PartyInformation = () => {
         option={BACKNAVIGATION_OPTIONS.MENU}
       />
       <Image
-        fallbackSrc='./logo.svg'
+        fallbackSrc='/skeleton.svg'
         src={partyInformation.coverImage}
         mt='3.75rem'
         h='200px'

--- a/src/components/party/partyInformation/PartyMenuTabList.tsx
+++ b/src/components/party/partyInformation/PartyMenuTabList.tsx
@@ -21,13 +21,7 @@ const PartyMenuTabList = () => {
   ];
 
   return (
-    <Tabs
-      defaultIndex={now}
-      pos='sticky'
-      top='3.75rem'
-      bg='white'
-      zIndex='20'
-      colorScheme='red'>
+    <Tabs index={now} pos='sticky' top='3.75rem' bg='white' zIndex='20' colorScheme='red'>
       <TabList>
         {partyTab.map((tab) => (
           <Link key={tab.name} to={tab.to} style={{ width: '100%' }}>

--- a/src/components/party/partyList/PartyListCard.tsx
+++ b/src/components/party/partyList/PartyListCard.tsx
@@ -42,7 +42,7 @@ const PartyListCard = ({
         overflow='hidden'
         variant='unstyled'>
         <Image
-          fallbackSrc='./logo.svg'
+          fallbackSrc='/skeleton.svg'
           objectFit='cover'
           borderRadius='2'
           minW={{ base: '10rem' }}
@@ -52,8 +52,8 @@ const PartyListCard = ({
           src={coverImage ? coverImage : '/logo.svg'}
         />
 
-        <Stack maxW='calc(100% - 4rem)' justifyContent='space-between' px='4' pb='3'>
-          <CardBody maxW='70%'>
+        <Stack maxW='calc(100% - 10rem)' justifyContent='space-between' px='4' pb='3'>
+          <CardBody>
             <Heading noOfLines={1} size='md'>
               {name}
             </Heading>

--- a/src/components/party/partyList/PartyListGrid.tsx
+++ b/src/components/party/partyList/PartyListGrid.tsx
@@ -35,39 +35,41 @@ const PartyListGrid = () => {
   return (
     <Box mt='6'>
       <Heading size='md'>내 모임 목록</Heading>
-      {myPartyList.party.length ? (
-        myPartyList.party.map(({ id, coverImage, name }) => (
-          <SimpleGrid key={id} mt='4' columns={3} spacing='10px'>
-            <Flex
-              cursor='pointer'
-              onClick={() => onMovePartyPage(id)}
-              direction='column'
-              justify='center'
-              align='center'>
-              <Image
-                fallbackSrc='./logo.svg'
-                src={coverImage ? coverImage : '/logo.svg'}
-                boxSize='80px'
-                objectFit='cover'
-                borderRadius='1.25rem'
-                alt={name}
-              />
-              <Heading
-                mt='2'
-                size='xs'
-                wordBreak='break-all'
-                textAlign='center'
-                noOfLines={1}>
-                {name}
-              </Heading>
-            </Flex>
-          </SimpleGrid>
-        ))
-      ) : (
-        <Text textAlign='center' p='2rem'>
-          참여 중인 모임이 없어요!
-        </Text>
-      )}
+      <SimpleGrid mt='4' columns={3} spacing='10px'>
+        {myPartyList.party.length ? (
+          myPartyList.party.map(({ id, coverImage, name }) => (
+            <Box key={id}>
+              <Flex
+                cursor='pointer'
+                onClick={() => onMovePartyPage(id)}
+                direction='column'
+                justify='center'
+                align='center'>
+                <Image
+                  fallbackSrc='/skeleton.svg'
+                  src={coverImage ? coverImage : '/logo.svg'}
+                  boxSize='80px'
+                  objectFit='cover'
+                  borderRadius='1.25rem'
+                  alt={name}
+                />
+                <Heading
+                  mt='2'
+                  size='xs'
+                  wordBreak='break-all'
+                  textAlign='center'
+                  noOfLines={1}>
+                  {name}
+                </Heading>
+              </Flex>
+            </Box>
+          ))
+        ) : (
+          <Text textAlign='center' p='2rem'>
+            참여 중인 모임이 없어요!
+          </Text>
+        )}
+      </SimpleGrid>
     </Box>
   );
 };

--- a/src/components/party/partyPlan/PlanPlaceList.tsx
+++ b/src/components/party/partyPlan/PlanPlaceList.tsx
@@ -96,7 +96,7 @@ const PlanPlaceList = ({ places }: PlanPlaceListProps) => {
           marginBottom='3'
           height='7rem'>
           <Image
-            fallbackSrc='./logo.svg'
+            fallbackSrc='/skeleton.svg'
             src={place.image}
             alt={place.name}
             width='30%'

--- a/src/components/party/schedule/CommentFeedItem.tsx
+++ b/src/components/party/schedule/CommentFeedItem.tsx
@@ -69,7 +69,7 @@ const CommentFeedItem = ({
         <Text p='0.625rem 0'>{content}</Text>
         {image && (
           <Image
-            fallbackSrc='./logo.svg'
+            fallbackSrc='/skeleton.svg'
             src={image}
             w='100%'
             m='0 auto'

--- a/src/components/party/schedule/RouteCommentFeed.tsx
+++ b/src/components/party/schedule/RouteCommentFeed.tsx
@@ -36,7 +36,7 @@ const RouteCommentFeed = () => {
     data: commentList,
     isLoading: commentLoading,
     isError: commentError,
-  } = useQuery<CommentListType>(['commentList'], () =>
+  } = useQuery<CommentListType>(['commentList', state.locationId], () =>
     fetchRouteCommentList(0, state.locationId)
   );
 

--- a/src/components/party/schedule/RouteTimelineItem.tsx
+++ b/src/components/party/schedule/RouteTimelineItem.tsx
@@ -55,7 +55,11 @@ const RouteTimelineItem = ({
             {getPriceText(spending)}
           </Text>
         </Flex>
-        <Box onClick={() => onClickHandler(id, partyId)} w='70%' pos='relative' ml='1rem'>
+        <Box
+          onClick={() => onClickHandler?.(id, partyId)}
+          w='70%'
+          pos='relative'
+          ml='1rem'>
           <Flex align='center' justify='space-between' mb='1.125rem'>
             <Heading size='sm'>{name}</Heading>
             {routerButton && (
@@ -66,8 +70,8 @@ const RouteTimelineItem = ({
           </Flex>
           <Card>
             <Image
-              fallbackSrc='./logo.svg'
-              src={image ? image : './logo.svg'}
+              fallbackSrc='/skeleton.svg'
+              src={image ? image : '/logo.svg'}
               w='100%'
               maxH='12.5rem'
               borderTopRadius='0.625rem'

--- a/src/components/routeList/BestRouteMoreList.tsx
+++ b/src/components/routeList/BestRouteMoreList.tsx
@@ -57,8 +57,11 @@ const BestRouteMoreList = () => {
               margin='0 auto 2rem auto'
               onClick={() => navigate(`/best-route/${partyId}`)}>
               <Image
-                fallbackSrc='./logo.svg'
-                src={image ? image : './logo.svg'}
+                w='sm'
+                h='3xs'
+                objectFit='cover'
+                fallbackSrc='/skeleton.svg'
+                src={image ? image : '/logo.svg'}
                 alt={image}
               />
               <Box p='6'>

--- a/src/components/routeList/LikeRouteList.tsx
+++ b/src/components/routeList/LikeRouteList.tsx
@@ -66,8 +66,8 @@ const LikeRouteList = () => {
               margin='0 auto 2rem auto'
               onClick={() => navigate(`/like-route/${partyId}`)}>
               <Image
-                fallbackSrc='./logo.svg'
-                src={image ? image : './logo.svg'}
+                fallbackSrc='/skeleton.svg'
+                src={image ? image : '/logo.svg'}
                 alt={name}
               />
 

--- a/src/components/routeList/PlaceLocationList.tsx
+++ b/src/components/routeList/PlaceLocationList.tsx
@@ -11,12 +11,14 @@ const PlaceLocationList = ({ locations }: RoutePlaceListProps) => {
       {locations.map(({ id, name, image, address }, index) => (
         <PlaceItem key={id}>
           <Flex flexDirection='column' alignItems='center' gap='1' justify='flex-start'>
-            <Text fontSize='0.375rem'>{address.split(' ')[0]}</Text>
+            <Text fontSize='0.5rem'>{address.split(' ')[0]}</Text>
             <Image
-              fallbackSrc='./logo.svg'
-              src={image ? image : './logo.svg'}
+              fallbackSrc='/skeleton.svg'
+              src={image ? image : '/logo.svg'}
               maxW='4rem'
+              w='4rem'
               h='4rem'
+              objectFit='cover'
               borderRadius='4'
             />
             <Text

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -33,7 +33,7 @@ const LandingPage = () => {
         <StyledSlider {...settings}>
           {LandingPageItem.map(({ id, imageUrl, content }) => (
             <VStack key={id} textAlign='center'>
-              <Image src={imageUrl} w='100%' />
+              <Image fallbackSrc='/skeleton.svg' src={imageUrl} w='100%' />
               <Text fontWeight='bold' fontSize='1.2rem' pt='1rem' wordBreak='keep-all'>
                 {content}
               </Text>

--- a/src/pages/PlacePage.tsx
+++ b/src/pages/PlacePage.tsx
@@ -64,7 +64,7 @@ const PlacePage = () => {
       )}
       <Box height='2xs' marginTop='14'>
         <Image
-          fallbackSrc='./logo.svg'
+          fallbackSrc='/skeleton.svg'
           src={data.image}
           height='3xs'
           width='full'


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #197

## 📖 구현 내용
- 이미지 로딩 중일 때 fallbackSrc로 스켈레톤 이미지 적용
- 내 정보 페이지에서 모임 목록 그리드 수정
- 베스트 루트 페이지 디자인 수정 
- 메인 페이지 오류 및 내 모임 목록 디자인 수정
- 모임 내 댓글 페이지 이전 데이터 깜빡이던 현상 해결

## 🖼 구현 이미지

![이미지 스켈레톤 이미지 적용](https://user-images.githubusercontent.com/107309247/225110813-ba85d3a9-4c5c-4eb4-ae56-64c4c637c24b.gif)
빨리 지나가서 잘 안보이지만 대충 저런 느낌..? 

## ✅ PR 포인트 & 궁금한 점
- 천욱쓰가 수정해준 코드도 합쳐서 pr 올려요~ 자잘한 코드 수정이라 파일체인지가 많습니당
- 스켈레톤을 img태그의 fallbackSrc로 사용하고 싶어서 css가 아니라 이미지로 사용했어요!