### PR TITLE
후보지 댓글 이미지 수정 에러 해결

### DIFF
--- a/src/components/party/schedule/CommentCreate.tsx
+++ b/src/components/party/schedule/CommentCreate.tsx
@@ -43,7 +43,6 @@ const CommentCreate = () => {
 
     setIsImageUploading(true);
     const compressedImageFile = await compressImage(image);
-    console.log(compressedImageFile);
     setIsImageUploading(false);
 
     const formData = new FormData();

--- a/src/components/place/comment/CommentForm.tsx
+++ b/src/components/place/comment/CommentForm.tsx
@@ -107,7 +107,7 @@ const CommentForm = ({
 
   const onEditCommentSubmit = async () => {
     if (!commentId) return;
-    if (!content && !imageValues.imageFile) {
+    if (!content && !imageValues.imageBase64) {
       Toast.show({
         message: PLACE_ERROR_MESSAGES.COMMENT_REQUIRED,
         type: 'warning',
@@ -115,10 +115,15 @@ const CommentForm = ({
       return;
     }
 
+    let image;
+    if (oldImage === imageValues.imageBase64) image = oldImage;
+    else if (imageValues.imageBase64) image = await onSubmitImageFile();
+    else image = '';
+
     const placeCommentBody = {
       id: commentId,
       content,
-      image: imageValues.imageBase64 ? await onSubmitImageFile() : oldImage,
+      image,
     };
 
     await editComment(placeCommentBody, {
@@ -211,7 +216,7 @@ const CommentForm = ({
               onClick={() => {
                 type === 'create' ? onCreateCommentSubmit() : onEditCommentSubmit();
               }}
-              isDisabled={!content && !imageValues.imageFile}>
+              isDisabled={!content && !imageValues.imageBase64}>
               등록
             </Button>
           </Flex>

--- a/src/components/place/comment/CommentList.tsx
+++ b/src/components/place/comment/CommentList.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Button,
   Flex,
   Image,
   Table,
@@ -77,17 +78,25 @@ const CommentList = ({ placeId }: CommentListProps) => {
                           {memberRole && <Tag size='sm'>{memberRole}</Tag>}
                         </Box>
                       </Flex>
-                      {isEditable && (
-                        <MoreMenu
-                          onEditEvent={() =>
-                            setEditing({ isEditing: true, commentId: id })
-                          }
-                          onRemoveEvent={() => {
-                            setCommentId(id);
-                            onOpen();
-                          }}
-                        />
-                      )}
+                      {isEditable &&
+                        (editing.isEditing ? (
+                          <Button
+                            variant='ghost'
+                            size='xs'
+                            onClick={() => setEditing({ ...editing, isEditing: false })}>
+                            취소
+                          </Button>
+                        ) : (
+                          <MoreMenu
+                            onEditEvent={() =>
+                              setEditing({ isEditing: true, commentId: id })
+                            }
+                            onRemoveEvent={() => {
+                              setCommentId(id);
+                              onOpen();
+                            }}
+                          />
+                        ))}
                     </Flex>
                     {editing.isEditing && editing.commentId === id ? (
                       <CommentForm


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #194 

## 📖 구현 내용
- 후보지 댓글 수정할 때 이미지를 삭제하면 이미지가 계속 유지되는 에러 해결
  - `image: ''`로 api 요청해야 수정 처리됨
- 후보지 댓글 수정 취소 버튼 추가

## 🖼 구현 이미지

<img width="40%" src="https://user-images.githubusercontent.com/63575891/226152355-b439e571-fdde-4201-a68c-429fba2293bb.gif" />


## ✅ PR 포인트 & 궁금한 점
-