### PR TITLE
후보지 방문예정일 범위 제한

### DIFF
--- a/src/components/place/create/information/DateTimeInput.tsx
+++ b/src/components/place/create/information/DateTimeInput.tsx
@@ -12,10 +12,7 @@ import { fetchPartyInformation } from '@/api/party';
 import Loading from '@/components/base/Loading';
 import { createPlaceState } from '@/store/recoilPlaceState';
 import { PartyInformationType } from '@/types/party';
-
-type DateTimeInputProps = {
-  partyId: number;
-};
+import { DateTimeInputProps } from '@/types/place';
 
 const DateTimeInput = ({ partyId }: DateTimeInputProps) => {
   const {
@@ -55,7 +52,7 @@ const DateTimeInput = ({ partyId }: DateTimeInputProps) => {
   return (
     <>
       <Text fontSize='sm' pb='1rem'>
-        모임 시작일과 종료일 사이로 지정할 수 있어요.
+        모임 기간 내 방문예정일을 선택해 주세요.
       </Text>
       <Calendar
         locale='ko'

--- a/src/components/place/create/information/PlaceInformationModal.tsx
+++ b/src/components/place/create/information/PlaceInformationModal.tsx
@@ -98,7 +98,7 @@ const PlaceInformationModal = () => {
     <>
       <ModalBody>
         <Accordion allowToggle>
-          {PlaceInformationItems.map(({ type, icon, text, content }) => (
+          {PlaceInformationItems(state.partyId).map(({ type, icon, text, content }) => (
             <AccordionItem key={type}>
               <AccordionButton justifyContent='space-between'>
                 <Flex gap='1.5' align='center'>

--- a/src/pages/PlaceCreatePage.tsx
+++ b/src/pages/PlaceCreatePage.tsx
@@ -41,7 +41,7 @@ const PlaceCreatePage = () => {
   const isFirstStep = () => step === processStep.min;
 
   const onCloseModal = () => {
-    !isFirstStep ? setStep(step - 1) : onConfirmModalOpen();
+    isFirstStep() ? onConfirmModalOpen() : setStep(step - 1);
   };
 
   return (

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -59,6 +59,16 @@ const globalStyle = css`
         .react-calendar--selectRange .react-calendar__tile--hover {
           background-color: #f4cf47;
         }
+
+        .react-calendar__tile:disabled {
+          color: grey;
+          cursor: not-allowed;
+        }
+
+        .react-calendar__navigation button:disabled {
+          background-color: initial;
+          cursor: not-allowed;
+        }
       }
     }
 

--- a/src/types/place.d.ts
+++ b/src/types/place.d.ts
@@ -190,3 +190,7 @@ export type CommentFormProps = {
   commentId?: number;
   setEditHandler?: () => void;
 };
+
+export type DateTimeInputProps = {
+  partyId: number;
+};

--- a/src/types/place.d.ts
+++ b/src/types/place.d.ts
@@ -104,13 +104,6 @@ export type PlaceInformationType =
   | 'address'
   | 'category';
 
-export type PlaceInformationItem = {
-  type: PlaceInformationType;
-  icon: JSX.Element;
-  text: string;
-  content?: JSX.Element;
-};
-
 export type PlaceCreateStepItem = {
   title: string;
   component: JSX.Element;

--- a/src/utils/constants/processStep.tsx
+++ b/src/utils/constants/processStep.tsx
@@ -11,7 +11,7 @@ import PlaceInformationModal from '@/components/place/create/information/PlaceIn
 import PriceInput from '@/components/place/create/information/PriceInput';
 import PlaceSearchModal from '@/components/place/create/search/PlaceSearchModal';
 import { PartyCreateStepItem } from '@/types/party';
-import { PlaceCreateStepItem, PlaceInformationItem } from '@/types/place';
+import { PlaceCreateStepItem } from '@/types/place';
 
 export const partyCreateStepItems: PartyCreateStepItem[] = [
   {
@@ -43,12 +43,12 @@ export const placeCreateStepItems: PlaceCreateStepItem[] = [
   },
 ];
 
-export const PlaceInformationItems: PlaceInformationItem[] = [
+export const PlaceInformationItems = (partyId: number) => [
   {
     type: 'visitDate',
     icon: <MdCalendarToday />,
     text: '방문 예정일',
-    content: <DateTimeInput />,
+    content: <DateTimeInput partyId={partyId} />,
   },
   {
     type: 'expectedCost',


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #198

## 📖 구현 내용
- 모임 진행 기간 내에만 후보지 방문 예정일을 선택할 수 있도록 minDate와 maxDate 추가
- 후보지 추가 모달에서 뒤로가기 및 닫기 처리 로직 정정

## 🖼 구현 이미지
<img width="296" alt="스크린샷 2023-03-19 오후 2 02 53" src="https://user-images.githubusercontent.com/63575891/226154857-5ef578d7-0d67-4931-b3d9-5d7cbf068ca4.png">

**피드백 반영 후**
(색상과 `cursor: not-allowed` 속성 추가로 적용했습니다)
<img width="296" alt="스크린샷 2023-03-20 오후 3 53 49" src="https://user-images.githubusercontent.com/63575891/226267787-6f6dc95b-07f4-4030-8470-d666bcd1c2ed.png">


## ✅ PR 포인트 & 궁금한 점
- 일단 리액트 캘린더에서 적용하는 기본 스타일 그대로 두었는데(선택 가능일은 흰 배경, 불가능한 날은 회색 배경) 생각보다 안 예쁘네요ㅠ 어떻게 보여주면 좋을지에 대한 의견 주시면 감사하겠습니다!
- '모임 시작일과 종료일 사이로 지정할 수 있어요' 멘트도 약간 와닿지 않는 것 같은데 괜찮나요? 다른 의견 있으면 남겨주세용!