### PR TITLE
서브타이틀 동적 변경 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       name="twitter:description"
       content="모임 계획은 우모에서, 우리들의 모임 WuMo"
     />
-    <title>WuMo</title>
+    <title>WuMo | 우리들의 모임</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -19,6 +19,7 @@ import { fetchScheduleList } from '@/api/schedules';
 import Loading from '@/components/base/Loading';
 import Toast from '@/components/base/toast/Toast';
 import BackNavigation from '@/components/navigation/BackNavigation';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import useScrollEvent from '@/hooks/useScrollEvent';
 import { CalculateStayDurationProps, PartyInformationType } from '@/types/party';
 import { ScheduleType } from '@/types/schedule';
@@ -61,6 +62,11 @@ const PartyInformation = () => {
       staleTime: 10000,
     }
   );
+
+  useDocumentTitle(
+    partyInformation ? `WuMo | ${partyInformation.name}` : 'WuMo | 우리들의 모임'
+  );
+
   const { data: scheduleList, refetch } = useQuery<ScheduleType>(
     ['ReceiptScheduleList', partyId],
     () => fetchScheduleList(Number(partyId), false),

--- a/src/components/party/partyInformation/PartyInformation.tsx
+++ b/src/components/party/partyInformation/PartyInformation.tsx
@@ -64,7 +64,7 @@ const PartyInformation = () => {
   );
 
   useDocumentTitle(
-    partyInformation ? `WuMo | ${partyInformation.name}` : 'WuMo | 우리들의 모임'
+    partyInformation ? `WuMoㅤ|ㅤ${partyInformation.name}` : 'WuMoㅤ|ㅤ우리들의 모임'
   );
 
   const { data: scheduleList, refetch } = useQuery<ScheduleType>(

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,9 @@
+import { useIsomorphicLayoutEffect } from 'framer-motion';
+
+function useDocumentTitle(title: string): void {
+  useIsomorphicLayoutEffect(() => {
+    document.title = title;
+  }, [title]);
+}
+
+export default useDocumentTitle;

--- a/src/pages/BestRouteListPage.tsx
+++ b/src/pages/BestRouteListPage.tsx
@@ -2,9 +2,11 @@ import { Box } from '@chakra-ui/react';
 
 import BackNavigation from '@/components/navigation/BackNavigation';
 import BestRouteMoreList from '@/components/routeList/BestRouteMoreList';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 
 const BestRouteListPage = () => {
+  useDocumentTitle('WuMo | 베스트 모임 루트');
   return (
     <>
       <BackNavigation title='베스트 루트 목록' option={BACKNAVIGATION_OPTIONS.SEARCH} />

--- a/src/pages/BestRouteListPage.tsx
+++ b/src/pages/BestRouteListPage.tsx
@@ -6,7 +6,7 @@ import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 
 const BestRouteListPage = () => {
-  useDocumentTitle('WuMo | 베스트 모임 루트');
+  useDocumentTitle('WuMoㅤ|ㅤ베스트 모임 루트');
   return (
     <>
       <BackNavigation title='베스트 루트 목록' option={BACKNAVIGATION_OPTIONS.SEARCH} />

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -8,6 +8,7 @@ import { fetchMyProfileInfo } from '@/api/user';
 import ConfirmModal from '@/components/base/ConfirmModal';
 import Loading from '@/components/base/Loading';
 import Toast from '@/components/base/toast/Toast';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { UserProps } from '@/types/user';
 import ROUTES from '@/utils/constants/routes';
 
@@ -19,6 +20,7 @@ const InvitationPage = () => {
   const { isOpen, onClose, onOpen } = useDisclosure();
   const [storedValue] = useLocalStorage('tokens', {});
   const [, setValue] = useLocalStorage('invitation', {});
+  useDocumentTitle('WuMo | 우리들의 모임');
 
   useEffect(() => {
     if (!storedValue.accessToken) {
@@ -92,12 +94,12 @@ const InvitationPage = () => {
         body={
           <Flex direction='column' align='center' justify='center'>
             <Heading size='lg' mb='1.5rem'>
-              파티에 초대되었어요!
+              모임에 초대되었어요!
             </Heading>
             <Text wordBreak='keep-all' textAlign='center' pb='0.625rem'>
               모임에서 {myInformation?.nickname}님을 초대하셨어요.
             </Text>
-            <Text>파티에 참여하시겠습니까?</Text>
+            <Text>모임에 참여하시겠습니까?</Text>
           </Flex>
         }
         clickButtonHandler={{

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -20,7 +20,7 @@ const InvitationPage = () => {
   const { isOpen, onClose, onOpen } = useDisclosure();
   const [storedValue] = useLocalStorage('tokens', {});
   const [, setValue] = useLocalStorage('invitation', {});
-  useDocumentTitle('WuMo | 우리들의 모임');
+  useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 
   useEffect(() => {
     if (!storedValue.accessToken) {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -11,7 +11,7 @@ import { LandingPageItem } from '@/utils/constants/landingPageItem';
 import ROUTES from '@/utils/constants/routes';
 
 const LandingPage = () => {
-  useDocumentTitle('WuMo | 우리들의 모임');
+  useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
   const navigate = useNavigate();
 
   const settings = {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -6,10 +6,12 @@ import { useNavigate } from 'react-router';
 import Slider from 'react-slick';
 
 import LargeLogo from '@/components/base/LargeLogo';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { LandingPageItem } from '@/utils/constants/landingPageItem';
 import ROUTES from '@/utils/constants/routes';
 
 const LandingPage = () => {
+  useDocumentTitle('WuMo | 우리들의 모임');
   const navigate = useNavigate();
 
   const settings = {

--- a/src/pages/LikeRouteListPage.tsx
+++ b/src/pages/LikeRouteListPage.tsx
@@ -2,8 +2,10 @@ import { Box } from '@chakra-ui/react';
 
 import BackNavigation from '@/components/navigation/BackNavigation';
 import LikeRouteList from '@/components/routeList/LikeRouteList';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const LikeRouteListPage = () => {
+  useDocumentTitle('WuMo | 관심 목록');
   return (
     <>
       <BackNavigation title='관심 목록' />

--- a/src/pages/LikeRouteListPage.tsx
+++ b/src/pages/LikeRouteListPage.tsx
@@ -5,7 +5,7 @@ import LikeRouteList from '@/components/routeList/LikeRouteList';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const LikeRouteListPage = () => {
-  useDocumentTitle('WuMo | 관심 목록');
+  useDocumentTitle('WuMoㅤ|ㅤ관심 목록');
   return (
     <>
       <BackNavigation title='관심 목록' />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -13,7 +13,7 @@ import useLocalStorage from '@/hooks/useLocalStorage';
 const MainPage = () => {
   const [storedValue] = useLocalStorage('invitation', {});
   const navigate = useNavigate();
-  useDocumentTitle('WuMo | 우리들의 모임');
+  useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 
   useEffect(() => {
     if (storedValue.roomId) {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -7,11 +7,13 @@ import BestRouteListPreview from '@/components/main/BestRouteListPreview';
 import MainHeader from '@/components/main/MainHeader';
 import PartCreateGuide from '@/components/main/PartCreateGuide';
 import UserPartyList from '@/components/main/UserPartyList';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import useLocalStorage from '@/hooks/useLocalStorage';
 
 const MainPage = () => {
   const [storedValue] = useLocalStorage('invitation', {});
   const navigate = useNavigate();
+  useDocumentTitle('WuMo | 우리들의 모임');
 
   useEffect(() => {
     if (storedValue.roomId) {

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -2,9 +2,11 @@ import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 
 import LargeLogo from '@/components/base/LargeLogo';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import ROUTES from '@/utils/constants/routes';
 
 const NotFoundPage = () => {
+  useDocumentTitle('WuMo | 404 Not Found');
   return (
     <Flex
       h='100vh'

--- a/src/pages/PartyCreatePage.tsx
+++ b/src/pages/PartyCreatePage.tsx
@@ -19,7 +19,7 @@ const PartyCreatePage = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useRecoilState<number>(stepState);
-  useDocumentTitle('WuMo | 새 모임 만들기');
+  useDocumentTitle('WuMoㅤ|ㅤ새 모임 만들기');
 
   const onClosePartyCreateModal = () => {
     setIsOpen(false);

--- a/src/pages/PartyCreatePage.tsx
+++ b/src/pages/PartyCreatePage.tsx
@@ -10,6 +10,7 @@ import { MdKeyboardArrowLeft } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { stepState } from '@/store/recoilPartyState';
 import { partyCreateStepItems, processStep } from '@/utils/constants/processStep';
 import ROUTES from '@/utils/constants/routes';
@@ -18,6 +19,7 @@ const PartyCreatePage = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useRecoilState<number>(stepState);
+  useDocumentTitle('WuMo | 새 모임 만들기');
 
   const onClosePartyCreateModal = () => {
     setIsOpen(false);

--- a/src/pages/PartyListPage.tsx
+++ b/src/pages/PartyListPage.tsx
@@ -4,7 +4,7 @@ import BackNavigation from '../components/navigation/BackNavigation';
 import PartyList from '../components/party/partyList/PartyList';
 
 const PartyListPage = () => {
-  useDocumentTitle('WuMo | 내 모임');
+  useDocumentTitle('WuMoㅤ|ㅤ내 모임');
   return (
     <>
       <BackNavigation title='내 모임 목록' />

--- a/src/pages/PartyListPage.tsx
+++ b/src/pages/PartyListPage.tsx
@@ -1,7 +1,10 @@
+import useDocumentTitle from '@/hooks/useDocumentTitle';
+
 import BackNavigation from '../components/navigation/BackNavigation';
 import PartyList from '../components/party/partyList/PartyList';
 
 const PartyListPage = () => {
+  useDocumentTitle('WuMo | 내 모임');
   return (
     <>
       <BackNavigation title='내 모임 목록' />

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -3,7 +3,7 @@ import ProfileEditForm from '@/components/profile/profileEdit/ProfileEditForm';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const ProfileEditPage = () => {
-  useDocumentTitle('WuMo | 내 정보 수정');
+  useDocumentTitle('WuMoㅤ|ㅤ내 정보 수정');
   return (
     <>
       <BackNavigation title='프로필 수정' />

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,7 +1,9 @@
 import BackNavigation from '@/components/navigation/BackNavigation';
 import ProfileEditForm from '@/components/profile/profileEdit/ProfileEditForm';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const ProfileEditPage = () => {
+  useDocumentTitle('WuMo | 내 정보 수정');
   return (
     <>
       <BackNavigation title='프로필 수정' />

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,8 +3,10 @@ import { Container } from '@chakra-ui/react';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import PartyListGrid from '@/components/party/partyList/PartyListGrid';
 import UserProfile from '@/components/profile/UserProfile';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const ProfilePage = () => {
+  useDocumentTitle('WuMo | 내 정보');
   return (
     <>
       <BackNavigation title='내 프로필' />

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -6,7 +6,7 @@ import UserProfile from '@/components/profile/UserProfile';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const ProfilePage = () => {
-  useDocumentTitle('WuMo | 내 정보');
+  useDocumentTitle('WuMoㅤ|ㅤ내 정보');
   return (
     <>
       <BackNavigation title='내 프로필' />

--- a/src/pages/RouteDetailPage.tsx
+++ b/src/pages/RouteDetailPage.tsx
@@ -3,14 +3,17 @@ import { useLocation } from 'react-router-dom';
 
 import BackNavigation from '@/components/navigation/BackNavigation';
 import RouteTimeline from '@/components/party/schedule/RouteTimeline';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const RouteDetailPage = () => {
   const { pathname } = useLocation();
 
   let pageTitle = '';
   if (pathname.includes('like-route')) {
+    useDocumentTitle('WuMo | 관심 루트');
     pageTitle = '관심 루트';
   } else if (pathname.includes('best-route')) {
+    useDocumentTitle('WuMo | 베스트 루트');
     pageTitle = '베스트 루트';
   }
 

--- a/src/pages/RouteDetailPage.tsx
+++ b/src/pages/RouteDetailPage.tsx
@@ -10,10 +10,10 @@ const RouteDetailPage = () => {
 
   let pageTitle = '';
   if (pathname.includes('like-route')) {
-    useDocumentTitle('WuMo | 관심 루트');
+    useDocumentTitle('WuMoㅤ|ㅤ관심 루트');
     pageTitle = '관심 루트';
   } else if (pathname.includes('best-route')) {
-    useDocumentTitle('WuMo | 베스트 루트');
+    useDocumentTitle('WuMoㅤ|ㅤ베스트 루트');
     pageTitle = '베스트 루트';
   }
 

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -7,7 +7,7 @@ import ToOtherSign from '@/components/userSign/ToOtherSign';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const SignInPage = () => {
-  useDocumentTitle('WuMo | 로그인');
+  useDocumentTitle('WuMoㅤ|ㅤ로그인');
   return (
     <Box py='4rem'>
       <BackNavigation />

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -4,8 +4,10 @@ import LargeLogo from '@/components/base/LargeLogo';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import SignInForm from '@/components/userSign/signIn/SignInForm';
 import ToOtherSign from '@/components/userSign/ToOtherSign';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const SignInPage = () => {
+  useDocumentTitle('WuMo | 로그인');
   return (
     <Box py='4rem'>
       <BackNavigation />

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -4,8 +4,10 @@ import LargeLogo from '@/components/base/LargeLogo';
 import BackNavigation from '@/components/navigation/BackNavigation';
 import SignUpForm from '@/components/userSign/signUp/SignUpForm';
 import ToOtherSign from '@/components/userSign/ToOtherSign';
+import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const SignUpPage = () => {
+  useDocumentTitle('WuMo | 회원가입');
   return (
     <Box py='4rem'>
       <BackNavigation />

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -7,7 +7,7 @@ import ToOtherSign from '@/components/userSign/ToOtherSign';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 const SignUpPage = () => {
-  useDocumentTitle('WuMo | 회원가입');
+  useDocumentTitle('WuMoㅤ|ㅤ회원가입');
   return (
     <Box py='4rem'>
       <BackNavigation />


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #219

## 📖 구현 내용
- useDocumentTitle hook 구현
- 각 페이지별 subTitle 추가
- 기본 Title -> "WuMo | 우리들의 모임" 으로 변경
- 모임 초대 페이지 "파티" -> "모임"으로 수정

## 🖼 구현 이미지
<details>
<summary>이미지 미리보기</summary>
<div markdown="1">

![Mar-30-2023 00-19-03](https://user-images.githubusercontent.com/82329983/228587060-274ca28f-2098-4943-93b9-05205eb12c7d.gif)

![Mar-30-2023 00-19-11](https://user-images.githubusercontent.com/82329983/228587084-ad934f5b-3950-4f05-868e-477babd96499.gif)

</div>
</details>


## ✅ PR 포인트 & 궁금한 점
- 모임 이름을 TItle로 활용하여 후보지 추가, 일정 댓글, 후보지 상세 페이지에서도 모임 이름이 보이도록 하였습니다.
- 한가지 문제점은 페이지 이동 후 새로고침하면 partyInformation.name 을 가져오기 어려워지지만 모임 이름이 보이는것이 사용성에 좋다고 판단되어서 이대로 PR 올립니다. 의견 주세요!

<details>
<summary>문제 GIF</summary>
<div markdown="1">

![Mar-30-2023 00-19-21](https://user-images.githubusercontent.com/82329983/228588222-fc344d0c-3986-4dc6-aefa-1c49292e406e.gif)

</div>
</details>

