### PR TITLE
구글 애널리틱스 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,15 @@
       content="모임 계획은 우모에서, 우리들의 모임 WuMo"
     />
     <title>WuMo | 우리들의 모임</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BB9SVBG7N3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-BB9SVBG7N3');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -23,15 +23,6 @@
       content="모임 계획은 우모에서, 우리들의 모임 WuMo"
     />
     <title>WuMo | 우리들의 모임</title>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BB9SVBG7N3"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-BB9SVBG7N3');
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.2.0",
         "react-calendar": "^4.0.0",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-hook-form": "^7.43.1",
         "react-icons": "^4.7.1",
         "react-kakao-maps-sdk": "^1.1.6",
@@ -8827,6 +8828,11 @@
         }
       }
     },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
+    },
     "node_modules/react-hook-form": {
       "version": "7.43.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.1.tgz",
@@ -16230,6 +16236,11 @@
         "use-callback-ref": "^1.3.0",
         "use-sidecar": "^1.1.2"
       }
+    },
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-hook-form": {
       "version": "7.43.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-calendar": "^4.0.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-hook-form": "^7.43.1",
     "react-icons": "^4.7.1",
     "react-kakao-maps-sdk": "^1.1.6",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -26,10 +26,12 @@ import {
 import PlaceEditPage from './pages/PlaceEditPage';
 import { PrivateRoute } from './utils/constants/redirect';
 import ROUTES from './utils/constants/routes';
+import RouteChangeTracker from './utils/RouteChangeTracker';
 
 const Router = () => {
   return (
     <BrowserRouter>
+      <RouteChangeTracker />
       <ScrollToTop />
       <Routes>
         <Route element={<BottomNavigation />}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import ReactGA from 'react-ga4';
 import { RecoilRoot } from 'recoil';
 
 import { AxiosInterceptor } from './api/api';
@@ -80,6 +81,9 @@ const theme = extendBaseTheme({
 });
 
 const queryClient = new QueryClient();
+
+const gaTrackingId = import.meta.env.VITE_GA_ID;
+ReactGA.initialize(gaTrackingId);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/utils/RouteChangeTracker.tsx
+++ b/src/utils/RouteChangeTracker.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
+
+const RouteChangeTracker = () => {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!window.location.href.includes('localhost')) {
+      ReactGA.initialize(import.meta.env.VITE_GA_ID);
+      setInitialized(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (initialized) {
+      ReactGA.set({ page: location.pathname });
+      ReactGA.send('pageview');
+    }
+  }, [initialized, location]);
+
+  return <></>;
+};
+
+export default RouteChangeTracker;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #225 

## 📖 구현 내용
react-ga4 설치하고 pr 내용 다시 작성합니다~~
- react-ga4 라이브러리를 설치하여 구글 애널리틱스 연동하였습니다.
- localhost(개발환경)는 집계되지 않도록 설정해두었어요.
-  `RouteChangeTracker.tsx` 는 주소가 바뀔 때마다 ga가 집계할 수 있도록 하는 컴포넌트입니다~

## 🖼 구현 이미지
![image](https://user-images.githubusercontent.com/107309247/230604021-4bb82cd3-bb94-40d6-a802-220791d591fd.png)
개발환경에서 테스트했을 때 통계 예시

## ✅ PR 포인트 & 궁금한 점
- wumo 공용 구글 계정에 연동해두었습니다. 
- `RouteChangeTracker.tsx`를 함수가 아니라 컴포넌트로 만든 이유는 useLocation을 사용해서 `BrowserRouter` 안에서 사용해야 됩니당 그래서 방법이 2가지가 있는데
1. `RouteChangeTracker` 를 함수로 사용하고 `Router` 컴포넌트에서 사용하던 `BrowserRouter`태그를 `main.tsx`로 옮긴다. 그리고 App.tsx에서 `RouteChangeTracker()` 호출한다.
2.  `RouteChangeTracker`를 컴포넌트로 만들어서 `Router` 컴포넌트  `BrowserRouter`태그 내에서 호출한다.

BrowserRouter 태그를 안 옮기는게 나을 것 같아서 2번 선택해서 했습니다! 어떨까요~~

- 환경변수 설정이 필요한데 머지되면 슬랙으로 공유해두겠습니다