### PR TITLE
모임 내 댓글 페이지 무한스크롤 적용

### DIFF
--- a/src/api/schedules.ts
+++ b/src/api/schedules.ts
@@ -17,10 +17,13 @@ export const fetchScheduleList = async (partyId: number, isPublic: boolean) => {
   }
 };
 
-export const fetchRouteCommentList = async (cursorId: number, locationId: number) => {
+export const fetchRouteCommentList = async (
+  cursorId: number | string,
+  locationId: number
+) => {
   try {
     const response = await axiosInstance.get(
-      `/party-route-comments?cursorId=&pageSize=1000&locationId=${locationId}`
+      `/party-route-comments?cursorId=${cursorId}&pageSize=5&locationId=${locationId}`
     );
     if (response) return response.data;
   } catch (error) {

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const option = {
+  root: null,
+  rootMargin: '0px',
+  threshold: 0,
+};
+
+const useIntersectionObserver = (fetchNextPage: () => void) => {
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => entries[0].isIntersecting && fetchNextPage(),
+      option
+    );
+
+    observer.observe(target);
+    return () => observer && observer.unobserve(target);
+  }, [target]);
+
+  return { setTarget };
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #210

## 📖 구현 내용
- 모임 내 일정 댓글 페이지 무한스크롤 적용하였습니다.
- 옵저버 커스텀 훅 만들어두었습니다.

## 🖼 구현 이미지
![댓글 페이지 무한스크롤](https://user-images.githubusercontent.com/107309247/230916834-fb76dd6d-16e4-46b1-8c86-bdca656f9e31.gif)


## ✅ PR 포인트 & 궁금한 점
- 옵저버 커스텀 훅을 만들긴 했는데 라이브러리를 쓸지 훅을 쓸지 정해야 될 것 같네요~
- intersectionOberserver 에서 옵션을 고정값으로 주었는데 props로 받는 게 나을까요 ~?