### PR TITLE
베스트 루트 목록 제목 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - 일정을 하나의 타임라인으로 묶어 한눈에 파악한다.
 - 다녀온 장소의 피드를 작성하여 추억을 기록한다.
 - 영수증 기능을 활용하여 정산할 때 도움을 받을 수 있다.
-- 다른 사람들과 루트를 공유하거나 지역을 검색해 추천 루트를 확인한다.
+- 다른 사람들과 일정을 공유하거나 지역을 검색해 추천 일정을 확인한다.
 - 마음에 드는 일정을 관심 목록에 추가하고 모아본다.
 
 <details>
@@ -52,8 +52,8 @@
  <img width="40%" src="https://user-images.githubusercontent.com/63575891/225986588-e84deef4-c99b-4aab-9164-6161698f0298.gif" alt="일정 관리 및 피드">
  </details>
  <details>
- <summary><h4>베스트 루트 조회 및 관심 목록</h4></summary>
- <img width="40%" src="https://user-images.githubusercontent.com/63575891/225985170-7012e7ce-790c-4d20-bfdf-b0bf5ed7edd2.gif" alt="베스트 루트 조회 및 관심 목록"/>
+ <summary><h4>추천 일정 및 관심 목록</h4></summary>
+ <img width="40%" src="https://user-images.githubusercontent.com/63575891/225985170-7012e7ce-790c-4d20-bfdf-b0bf5ed7edd2.gif" alt="추천 일정 및 관심 목록"/>
  </details>
 </details>
 
@@ -64,8 +64,8 @@
 |[김민재](https://github.com/mxx-kor)|[김유리](https://github.com/glassk)|[유지영](https://github.com/YJZero)|[주천욱](https://github.com/chunwookJoo)|
 |---|---|---|---|
 | <div align="center"><img height="150px" src="https://avatars.githubusercontent.com/mxx-kor" alt="mxx-kor"/></div> | <div align="center"><img height="150px" src="https://avatars.githubusercontent.com/glassk" alt="glassk" /></div> | <div align="center"><img height="150px" src="https://avatars.githubusercontent.com/YJZero" alt="YJZero" /></div> | <div align="center"><img height="150px" src="https://avatars.githubusercontent.com/chunwookJoo" alt="chunwookJoo" /></div> |
-| - 회원가입 및 로그인<br />- 프로필 조회 및 수정<br />- 모임 목록   | - 모임 계획<br />- 후보지 및 댓글                                | - 메인 페이지<br />- 모임 일정 및 피드<br />- 모임 초대            | - 베스트, 관심 루트 목록<br />- 모임 추가 및 관리<br />- 랜딩, 404 페이지 |
-| - react-hook-form을 활용한 리렌더링 최소화, 유효성 검증 구현<br />- axios interceptor를 활용하여 API 요청, 에러, 응답 및 JWT 토큰 관리 | - kakao maps API를 활용한 지도 뷰 및 검색 기능 구현<br />- 프로젝트 초기 세팅<br /> - 백엔드 서버 부하를 고려한 대용량 이미지 압축 | - tanstack query의 에러 핸들링과 refetch를 활용한 데이터 통신<br />- 컴포넌트 재사용성을 위한 Modal 등 공통 컴포넌트 분리<br />- react-router-dom의 동적 라우팅을 이용한 초대 기능 구현 | - 베스트 루트 좋아요 디바운싱 커스텀 훅 분리<br />- recoil을 활용한 모임 추가 단계 및 유저 데이터 상태관리 |
+| - 회원가입 및 로그인<br />- 프로필 조회 및 수정<br />- 모임 목록   | - 모임 계획<br />- 후보지 및 댓글                                | - 메인 페이지<br />- 모임 일정 및 피드<br />- 모임 초대            | - 추천 일정, 관심 일정 목록<br />- 모임 추가 및 관리<br />- 랜딩, 404 페이지 |
+| - react-hook-form을 활용한 리렌더링 최소화, 유효성 검증 구현<br />- axios interceptor를 활용하여 API 요청, 에러, 응답 및 JWT 토큰 관리 | - kakao maps API를 활용한 지도 뷰 및 검색 기능 구현<br />- 프로젝트 초기 세팅<br /> - 백엔드 서버 부하를 고려한 대용량 이미지 압축 | - tanstack query의 에러 핸들링과 refetch를 활용한 데이터 통신<br />- 컴포넌트 재사용성을 위한 Modal 등 공통 컴포넌트 분리<br />- react-router-dom의 동적 라우팅을 이용한 초대 기능 구현 | - 추천 일정 좋아요 디바운싱 커스텀 훅 분리<br />- recoil을 활용한 모임 추가 단계 및 유저 데이터 상태관리 |
 
 <br />
 

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -24,8 +24,8 @@ import {
   SignUpPage,
 } from './pages';
 import PlaceEditPage from './pages/PlaceEditPage';
-import { PrivateRoute } from './utils/constants/redirect';
 import ROUTES from './utils/constants/routes';
+import { RedirectRouter } from './utils/RedirectRouter';
 import RouteChangeTracker from './utils/RouteChangeTracker';
 
 const Router = () => {
@@ -35,68 +35,68 @@ const Router = () => {
       <ScrollToTop />
       <Routes>
         <Route element={<BottomNavigation />}>
-          <Route element={<PrivateRoute redirectPath={ROUTES.LANDING} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.LANDING} />}>
             <Route path={ROUTES.MAIN} element={<MainPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.LIKE} element={<LikeRouteListPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PARTY_CREATE} element={<PartyCreatePage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PLACE_NEW} element={<PlaceCreatePage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.BEST_ROUTE_LIST} element={<BestRouteListPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.BEST_ROUTE_DETAIL} element={<RouteDetailPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.LIKE_DETAIL} element={<RouteDetailPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PARTY_LIST} element={<PartyListPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PROFILE} element={<ProfilePage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PROFILE_EDIT} element={<ProfileEditPage />} />
           </Route>
 
           <Route path={ROUTES.PARTY} element={<PartyInformation />}>
-            <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+            <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
               <Route index element={<PartySchedulePage />} />
             </Route>
-            <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+            <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
               <Route path={ROUTES.PLAN} element={<PartyPlanPage />} />
             </Route>
           </Route>
 
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.SCHEDULE_COMMENT} element={<PartyCommentPage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PLACE_DETAIL} element={<PlacePage />} />
           </Route>
-          <Route element={<PrivateRoute redirectPath={ROUTES.NOTFOUND} />}>
+          <Route element={<RedirectRouter redirectPath={ROUTES.NOTFOUND} />}>
             <Route path={ROUTES.PLACE_EDIT} element={<PlaceEditPage />} />
           </Route>
         </Route>
 
         {/* BottomNav 없는 페이지 */}
         <Route
-          element={<PrivateRoute authentication={false} redirectPath={ROUTES.MAIN} />}>
+          element={<RedirectRouter authentication={false} redirectPath={ROUTES.MAIN} />}>
           <Route path={ROUTES.LANDING} element={<LandingPage />} />
         </Route>
         <Route
-          element={<PrivateRoute authentication={false} redirectPath={ROUTES.MAIN} />}>
+          element={<RedirectRouter authentication={false} redirectPath={ROUTES.MAIN} />}>
           <Route path={ROUTES.SIGNUP} element={<SignUpPage />} />
         </Route>
         <Route
-          element={<PrivateRoute authentication={false} redirectPath={ROUTES.MAIN} />}>
+          element={<RedirectRouter authentication={false} redirectPath={ROUTES.MAIN} />}>
           <Route path={ROUTES.SIGNIN} element={<SignInPage />} />
         </Route>
         <Route path={ROUTES.INVITATION} element={<InvitationPage />} />

--- a/src/api/schedules.ts
+++ b/src/api/schedules.ts
@@ -31,7 +31,7 @@ export const fetchRouteCommentList = async (
   }
 };
 
-// 공개된 루트 (베스트루트 목록) 조회
+// 공개된 추천 일정 (추천 일정 목록) 조회
 export const fetchBestRouteList = async ({
   cursorId,
   pageSize,

--- a/src/components/base/SearchInput.tsx
+++ b/src/components/base/SearchInput.tsx
@@ -79,8 +79,7 @@ const SearchInput = () => {
           </MenuButton>
           <MenuList>
             <MenuItem onClick={() => onClickHandleSortType('NEWEST')}>최신순</MenuItem>
-            {/* 백엔드 API 수정 후 구현 예정 @chunwookJoo */}
-            {/* <MenuItem onClick={() => onClickHandleSortType('LIKES')}>좋아요순</MenuItem> */}
+            <MenuItem onClick={() => onClickHandleSortType('LIKES')}>좋아요순</MenuItem>
           </MenuList>
         </Menu>
         <Input

--- a/src/components/main/BestRouteListPreview.tsx
+++ b/src/components/main/BestRouteListPreview.tsx
@@ -71,7 +71,7 @@ const BestRouteListPreview = () => {
   return (
     <>
       <Flex direction='row' justify='space-between' align='center' p='1.25rem 1.875rem'>
-        <Heading size='sm'>베스트 모임루트</Heading>
+        <Heading size='sm'>추천 일정 모아보기</Heading>
         <Button size='sm' onClick={onMoveBestRoutePage}>
           더보기
         </Button>

--- a/src/components/party/schedule/RouteTitle.tsx
+++ b/src/components/party/schedule/RouteTitle.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { MdFavorite, MdFavoriteBorder, MdShare } from 'react-icons/md';
 
 import { createLikeRoute, deleteLikeRoute } from '@/api/route';
+import Toast from '@/components/base/toast/Toast';
 import useDebounce from '@/hooks/useDebounce';
 import { ScheduleType } from '@/types/schedule';
 
@@ -18,10 +19,11 @@ const RouteTitle = ({ scheduleList }: { scheduleList: ScheduleType }) => {
   };
 
   const copyCurrentUrl = () => {
-    navigator.share({
-      title: '우리들의 모임, WuMo',
-      text: '베스트 루트 공유',
-      url: `https://5yes-wumo.vercel.app/best-route/${partyId}`,
+    navigator.clipboard.writeText(`${window.location.origin}/best-route/${partyId}`);
+    Toast.show({
+      title: '',
+      message: '해당 일정이 클립보드에 복사되었습니다!',
+      type: 'success',
     });
   };
 

--- a/src/components/party/schedule/routeRelease/RouteReleaseChange.tsx
+++ b/src/components/party/schedule/routeRelease/RouteReleaseChange.tsx
@@ -87,7 +87,7 @@ const RouteReleaseChange = ({
       <FormControl>
         <Flex align='center' justify='flex-end' px='16px' pt='8px'>
           <FormLabel htmlFor='release' m='0' mr='0.625rem'>
-            루트 공개
+            일정 공개
           </FormLabel>
           <Switch
             id='release'
@@ -104,16 +104,16 @@ const RouteReleaseChange = ({
         body={
           <Flex direction='column' align='center' pt='0'>
             <Heading size='md' mb='24px'>
-              루트 공개
+              일정 공개
             </Heading>
             <Text fontSize='sm'>
-              모임 루트를 공개할 경우 모든 사람이 내 루트를 구경할 수 있어요!
+              모임 일정을 공개할 경우 모든 사람이 내 일정을 구경할 수 있어요!
             </Text>
             <Text fontSize='sm' mb='2.25rem'>
-              (댓글은 공개되지 않으며 루트만 공개됩니다.)
+              (댓글은 공개되지 않으며 일정만 공개됩니다.)
             </Text>
 
-            <Text mb='2'>공개할 루트의 이름을 정해주세요.</Text>
+            <Text mb='2'>공개할 일정의 이름을 정해주세요.</Text>
             <Input isRequired {...register('routeName')} />
           </Flex>
         }
@@ -145,9 +145,9 @@ const RouteReleaseChange = ({
         body={
           <Flex direction='column' align='center' pt='0'>
             <Heading size='md' mb='24px'>
-              루트 비공개
+              일정 비공개
             </Heading>
-            <Text fontSize='sm'>모임 루트 공개를 취소하시겠습니까?</Text>
+            <Text fontSize='sm'>모임 일정 공개를 취소하시겠습니까?</Text>
           </Flex>
         }
         clickButtonHandler={{

--- a/src/components/routeList/LikeRouteList.tsx
+++ b/src/components/routeList/LikeRouteList.tsx
@@ -40,11 +40,17 @@ const LikeRouteList = () => {
           관심목록이 비어있어요.
         </Text>
         <Text mt='6'>
-          베스트 루트 목록에서 <br /> 마음에 드는 루트를 추가해보세요.
+          추천 일정 목록에서 <br /> 마음에 드는 일정을 추가해보세요.
         </Text>
         <Link to={ROUTES.BEST_ROUTE_LIST}>
-          <Button bg='primary.red' color='white' fontWeight='normal' px='2rem' mt='6'>
-            베스트 루트 보러가기
+          <Button
+            bg='primary.red'
+            color='white'
+            fontWeight='normal'
+            px='2rem'
+            mt='6'
+            _hover={{ bg: 'primary.redHover' }}>
+            추천 일정 목록 보러가기
           </Button>
         </Link>
       </Box>

--- a/src/components/routeList/LikeRouteList.tsx
+++ b/src/components/routeList/LikeRouteList.tsx
@@ -72,6 +72,9 @@ const LikeRouteList = () => {
               margin='0 auto 2rem auto'
               onClick={() => navigate(`/like-route/${partyId}`)}>
               <Image
+                w='sm'
+                h='3xs'
+                objectFit='cover'
                 fallbackSrc='/skeleton.svg'
                 src={image ? image : '/logo.svg'}
                 alt={name}

--- a/src/pages/BestRouteListPage.tsx
+++ b/src/pages/BestRouteListPage.tsx
@@ -1,15 +1,27 @@
 import { Box } from '@chakra-ui/react';
+import { useRecoilValue } from 'recoil';
 
 import BackNavigation from '@/components/navigation/BackNavigation';
 import BestRouteMoreList from '@/components/routeList/BestRouteMoreList';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
+import { recoilBestRouteListParams } from '@/store/recoilRouteListState';
+import { BestRouteListParamsType } from '@/types/routeList';
 import { BACKNAVIGATION_OPTIONS } from '@/utils/constants/navigationItem';
 
 const BestRouteListPage = () => {
-  useDocumentTitle('WuMoㅤ|ㅤ베스트 모임 루트');
+  useDocumentTitle('WuMoㅤ|ㅤ추천 일정 목록');
+  const bestRouteParams = useRecoilValue<BestRouteListParamsType>(
+    recoilBestRouteListParams
+  );
+
   return (
     <>
-      <BackNavigation title='베스트 루트 목록' option={BACKNAVIGATION_OPTIONS.SEARCH} />
+      <BackNavigation
+        title={
+          bestRouteParams.sortType === 'NEWEST' ? '최신 일정 목록' : '인기 일정 목록'
+        }
+        option={BACKNAVIGATION_OPTIONS.SEARCH}
+      />
       <Box p='10rem 2rem 2rem 2rem'>
         <BestRouteMoreList />
       </Box>

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -22,7 +22,12 @@ const NotFoundPage = () => {
       </Box>
       <Box>
         <Link to={ROUTES.MAIN}>
-          <Button bg='primary.red' color='white' fontWeight='normal' px='2rem'>
+          <Button
+            bg='primary.red'
+            color='white'
+            fontWeight='normal'
+            px='2rem'
+            _hover={{ bg: 'primary.redHover' }}>
             홈으로
           </Button>
         </Link>

--- a/src/pages/RouteDetailPage.tsx
+++ b/src/pages/RouteDetailPage.tsx
@@ -10,11 +10,11 @@ const RouteDetailPage = () => {
 
   let pageTitle = '';
   if (pathname.includes('like-route')) {
-    useDocumentTitle('WuMoㅤ|ㅤ관심 루트');
-    pageTitle = '관심 루트';
+    useDocumentTitle('WuMoㅤ|ㅤ관심 일정');
+    pageTitle = '관심 일정';
   } else if (pathname.includes('best-route')) {
-    useDocumentTitle('WuMoㅤ|ㅤ베스트 루트');
-    pageTitle = '베스트 루트';
+    useDocumentTitle('WuMoㅤ|ㅤ추천 일정');
+    pageTitle = '추천 일정';
   }
 
   return (

--- a/src/types/router.d.ts
+++ b/src/types/router.d.ts
@@ -1,4 +1,4 @@
-export type PrivateRouteProps = {
+export type RedirectRouterProps = {
   children?: ReactElement;
   authentication?: boolean;
   redirectPath: string;

--- a/src/utils/RedirectRouter.tsx
+++ b/src/utils/RedirectRouter.tsx
@@ -1,12 +1,12 @@
 import { ReactElement } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
-import { PrivateRouteProps } from '@/types/router';
+import { RedirectRouterProps } from '@/types/router';
 
-const PrivateRoute = ({
+const RedirectRouter = ({
   authentication = true,
   redirectPath,
-}: PrivateRouteProps): ReactElement | null => {
+}: RedirectRouterProps): ReactElement | null => {
   const tokens = localStorage.getItem('tokens');
 
   if (authentication) {
@@ -16,4 +16,4 @@ const PrivateRoute = ({
   }
 };
 
-export { PrivateRoute };
+export { RedirectRouter };


### PR DESCRIPTION
## 💡 Linked Issues
Resolve: #232 

## 📖 구현 내용
 - 베스트 루트 목록 제목 변경
 - 루트 단어를 일정으로 통일 시키기
 - 좋아요 api 확인 후 추가
 - 추천 일정 공유 버튼 안되는 에러

## 🖼 구현 이미지
![녹화_2023_04_19_01_38_27_806](https://user-images.githubusercontent.com/64945491/232845680-7b65395d-80b6-4c31-8354-a2f3a6460a43.gif)


## ✅ PR 포인트 & 궁금한 점
- 일정 공유 버튼 클릭시 나오는 Toast에는 너무 많은 메세지가 있는것보다 간결하게 복사만 되었다고 알려주는게 좋을 것 같아서 내용을 줄였습니다. 의견 주세요!
- 리드미쪽에도 루트 대신 일정으로 바꿨는데 확인부탁드려욥
- 좋아요순으로 데이터 잘 나오긴 하는데 한두개 누락되는 일정들이 있어서 백엔드쪽에 수정 요청 하겠습니다~