### PR TITLE
JWT 보안 개선

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
 import Toast from '@/components/base/toast/Toast';
+import { AT_KEY, GRANT_TYPE } from '@/utils/constants/auth';
+import { TOAST_MESSAGE } from '@/utils/constants/messages';
+
+import { reissueToken } from './user';
 
 type AxiosInterceptorChildrenType = {
   children: JSX.Element;
@@ -24,28 +28,28 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
   };
 
   const getRefreshToken = async (): Promise<string | void> => {
-    const token = localStorage.getItem('wumo_token');
+    const token = localStorage.getItem(AT_KEY);
     if (token) {
       try {
-        const response = await axiosInstance.post('/members/reissue', JSON.parse(token));
+        const response = await reissueToken(token);
         const { accessToken } = response.data;
         lock = false;
         onRrefreshed(accessToken);
         subscribers = [];
-        localStorage.setItem('wumo_token', JSON.stringify({ accessToken }));
+        localStorage.setItem(AT_KEY, JSON.stringify(accessToken));
 
         return accessToken;
       } catch (error) {
         lock = false;
         subscribers = [];
-        localStorage.removeItem('wumo_token');
         Toast.show({
-          title: '인증 정보에 문제가 발생하였습니다.',
-          message: '다시 로그인해주세요.',
-          duration: 3000,
+          title: TOAST_MESSAGE.FAILED_AUTH,
+          message: TOAST_MESSAGE.REQUEST_LOGIN,
+          duration: 1500,
           type: 'error',
           authError: true,
         });
+        localStorage.removeItem(AT_KEY);
       }
     }
   };
@@ -60,18 +64,18 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
       if (response?.status === 401 && originalConfig) {
         if (originalConfig.url === '/members/reissue') {
           Toast.show({
-            title: '인증 정보가 만료되었습니다.',
-            message: '다시 로그인해주세요.',
-            duration: 3000,
+            title: TOAST_MESSAGE.EXPIRED_TOKEN,
+            message: TOAST_MESSAGE.REQUEST_LOGIN,
+            duration: 1500,
             type: 'error',
             authError: true,
           });
-          localStorage.removeItem('wumo_token');
+          localStorage.removeItem(AT_KEY);
         }
         if (lock) {
           return new Promise((resolve) => {
             subscribeTokenRefresh((token: string) => {
-              originalConfig.headers.Authorization = `Bearer ${token}`;
+              originalConfig.headers.Authorization = `${GRANT_TYPE} ${token}`;
               resolve(axios(originalConfig));
             });
           });
@@ -80,7 +84,7 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
         lock = true;
         const accessToken = await getRefreshToken();
 
-        originalConfig.headers.Authorization = `Bearer ${accessToken}`;
+        originalConfig.headers.Authorization = `${GRANT_TYPE} ${accessToken}`;
         return axios(originalConfig);
       }
       return Promise.reject(error);
@@ -89,7 +93,7 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
 
   axiosInstance.interceptors.request.use(
     (config) => {
-      const token = localStorage.getItem('wumo_token');
+      const token = localStorage.getItem(AT_KEY);
 
       if (!token) {
         config.headers.Authorization = null;
@@ -102,8 +106,8 @@ const AxiosInterceptor = ({ children }: AxiosInterceptorChildrenType) => {
         config.headers['Content-Type'] = 'application/json';
       }
       if (!config.headers.Authorization) {
-        const { accessToken } = JSON.parse(token);
-        config.headers.Authorization = `Bearer ${accessToken}`;
+        const accessToken = JSON.parse(token);
+        config.headers.Authorization = `${GRANT_TYPE} ${accessToken}`;
         return config;
       }
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -9,7 +9,7 @@ import axiosInstance from './api';
 export const logout = async () => {
   try {
     await axiosInstance.delete('/members/logout');
-    localStorage.removeItem('tokens');
+    localStorage.removeItem('wumo_token');
   } catch (error) {
     console.error(error);
   }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -3,13 +3,14 @@ import axios from 'axios';
 import Toast from '@/components/base/toast/Toast';
 import { UserEditProps } from '@/types/user';
 import { SignInProps, SignProps } from '@/types/userSign';
+import { AT_KEY } from '@/utils/constants/auth';
 
 import axiosInstance from './api';
 
 export const logout = async () => {
   try {
     await axiosInstance.delete('/members/logout');
-    localStorage.removeItem('wumo_token');
+    localStorage.removeItem(AT_KEY);
   } catch (error) {
     console.error(error);
   }
@@ -45,6 +46,13 @@ export const signUp = async (values: SignProps) => {
       type: 'error',
     });
   }
+};
+
+export const reissueToken = async (token: string) => {
+  const response = await axiosInstance.post('/members/reissue', {
+    accessToken: JSON.parse(token),
+  });
+  return response;
 };
 
 export const fetchCheckEmail = async (target: string) => {

--- a/src/components/base/toast/Toast.tsx
+++ b/src/components/base/toast/Toast.tsx
@@ -40,6 +40,7 @@ class Toast {
     fontColor,
     title,
     titleColor,
+    authError = false,
   }: CreateToastParams) {
     this.createToast({
       message,
@@ -51,6 +52,7 @@ class Toast {
       fontColor,
       title,
       titleColor,
+      authError,
     });
   }
 }

--- a/src/components/base/toast/ToastItem.tsx
+++ b/src/components/base/toast/ToastItem.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
 import { ToastItemType } from '@/types/toast';
+import ROUTES from '@/utils/constants/routes';
 import { toastType } from '@/utils/constants/toast';
 
 const ToastItem = ({
@@ -16,12 +17,16 @@ const ToastItem = ({
   fontColor,
   title,
   titleColor,
+  authError,
 }: ToastItemType) => {
   const [show, setShow] = useState(true);
   useEffect(() => {
     setTimeout(() => {
       setShow(false);
       onDone();
+      if (authError) {
+        location.replace(ROUTES.LANDING);
+      }
     }, duration);
   }, []);
 

--- a/src/components/base/toast/ToastManager.tsx
+++ b/src/components/base/toast/ToastManager.tsx
@@ -26,6 +26,7 @@ const ToastManager = ({ bind }: ToastManagerProps) => {
       fontColor,
       title,
       titleColor,
+      authError,
     }: CreateToastParams) => {
       const newToast: ToastCreateType = {
         id: Math.random(),
@@ -38,6 +39,7 @@ const ToastManager = ({ bind }: ToastManagerProps) => {
         fontColor,
         title,
         titleColor,
+        authError,
       };
       setToasts((oldToasts) => [...oldToasts, newToast]);
     },
@@ -68,6 +70,7 @@ const ToastManager = ({ bind }: ToastManagerProps) => {
           fontColor,
           title,
           titleColor,
+          authError,
         }) => (
           <ToastItem
             key={id}
@@ -81,6 +84,7 @@ const ToastManager = ({ bind }: ToastManagerProps) => {
             fontColor={fontColor}
             title={title}
             titleColor={titleColor}
+            authError={authError}
           />
         )
       )}

--- a/src/components/userSign/signIn/SignInForm.tsx
+++ b/src/components/userSign/signIn/SignInForm.tsx
@@ -8,12 +8,13 @@ import ControlledInput from '@/components/base/input/ControlledInput';
 import SubmitButton from '@/components/base/SubmitButton';
 import useLocalStorage from '@/hooks/useLocalStorage';
 import { SignInProps } from '@/types/userSign';
+import { AT_KEY } from '@/utils/constants/auth';
 import ROUTES from '@/utils/constants/routes';
 import { signInSchema } from '@/utils/schema';
 
 const SignInForm = () => {
   const navigate = useNavigate();
-  const [, setToken] = useLocalStorage('wumo_token', {});
+  const [, setToken] = useLocalStorage(AT_KEY, {});
   const {
     control,
     handleSubmit,
@@ -32,9 +33,7 @@ const SignInForm = () => {
       const token = await signIn(values);
       if (token) {
         const { accessToken } = token;
-        setToken({
-          accessToken,
-        });
+        setToken(accessToken);
         navigate(ROUTES.MAIN, { replace: true });
       }
     } catch (error) {

--- a/src/components/userSign/signIn/SignInForm.tsx
+++ b/src/components/userSign/signIn/SignInForm.tsx
@@ -13,7 +13,7 @@ import { signInSchema } from '@/utils/schema';
 
 const SignInForm = () => {
   const navigate = useNavigate();
-  const [, setToken] = useLocalStorage('tokens', {});
+  const [, setToken] = useLocalStorage('wumo_token', {});
   const {
     control,
     handleSubmit,
@@ -29,12 +29,11 @@ const SignInForm = () => {
 
   const onSubmit = async (values: SignInProps) => {
     try {
-      const tokens = await signIn(values);
-      if (tokens) {
-        const { accessToken, refreshToken } = tokens;
+      const token = await signIn(values);
+      if (token) {
+        const { accessToken } = token;
         setToken({
           accessToken,
-          refreshToken,
         });
         navigate(ROUTES.MAIN, { replace: true });
       }

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -10,6 +10,7 @@ import Loading from '@/components/base/Loading';
 import Toast from '@/components/base/toast/Toast';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 import { UserProps } from '@/types/user';
+import { AT_KEY } from '@/utils/constants/auth';
 import ROUTES from '@/utils/constants/routes';
 
 import useLocalStorage from '../hooks/useLocalStorage';
@@ -18,7 +19,7 @@ const InvitationPage = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const [storedValue] = useLocalStorage('wumo_token', {});
+  const [storedValue] = useLocalStorage(AT_KEY, {});
   const [, setValue] = useLocalStorage('invitation', {});
   useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -18,7 +18,7 @@ const InvitationPage = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const [storedValue] = useLocalStorage('tokens', {});
+  const [storedValue] = useLocalStorage('wumo_token', {});
   const [, setValue] = useLocalStorage('invitation', {});
   useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -6,7 +6,7 @@ import useDocumentTitle from '@/hooks/useDocumentTitle';
 import ROUTES from '@/utils/constants/routes';
 
 const NotFoundPage = () => {
-  useDocumentTitle('WuMo | 404 Not Found');
+  useDocumentTitle('WuMoㅤ|ㅤ404 Not Found');
   return (
     <Flex
       h='100vh'

--- a/src/types/toast.d.ts
+++ b/src/types/toast.d.ts
@@ -8,6 +8,7 @@ export type CreateToastParams = {
   fontColor?: string;
   titleColor?: string;
   title?: string;
+  authError?: boolean;
 };
 
 export type CreateToastFn = (arg0: CreateToastParams) => void;

--- a/src/utils/constants/auth.ts
+++ b/src/utils/constants/auth.ts
@@ -1,0 +1,2 @@
+export const GRANT_TYPE = 'Bearer' as const;
+export const AT_KEY = 'wmsecure' as const;

--- a/src/utils/constants/messages.ts
+++ b/src/utils/constants/messages.ts
@@ -33,4 +33,7 @@ export const TOAST_MESSAGE = {
   SUCCESS_PARTY_REMOVE: '모임이 정상적으로 삭제되었습니다.',
   SUCCESS_PARTY_UPDATE: '모임이 정상적으로 수정되었습니다.',
   SUCCESS_PARTY_CREATE: '모임이 정상적으로 생성되었습니다.',
+  FAILED_AUTH: '인증 정보가 일치하지 않습니다.',
+  EXPIRED_TOKEN: '인증 정보가 만료되었습니다.',
+  REQUEST_LOGIN: '다시 로그인해주세요.',
 } as const;

--- a/src/utils/constants/redirect.tsx
+++ b/src/utils/constants/redirect.tsx
@@ -7,12 +7,12 @@ const PrivateRoute = ({
   authentication = true,
   redirectPath,
 }: PrivateRouteProps): ReactElement | null => {
-  const tokens = localStorage.getItem('tokens');
+  const token = localStorage.getItem('wumo_token');
 
   if (authentication) {
-    return tokens ? <Outlet /> : <Navigate to={redirectPath} />;
+    return token ? <Outlet /> : <Navigate to={redirectPath} />;
   } else {
-    return tokens ? <Navigate to={redirectPath} /> : <Outlet />;
+    return token ? <Navigate to={redirectPath} /> : <Outlet />;
   }
 };
 

--- a/src/utils/constants/redirect.tsx
+++ b/src/utils/constants/redirect.tsx
@@ -3,11 +3,13 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 import { PrivateRouteProps } from '@/types/router';
 
+import { AT_KEY } from './auth';
+
 const PrivateRoute = ({
   authentication = true,
   redirectPath,
 }: PrivateRouteProps): ReactElement | null => {
-  const token = localStorage.getItem('wumo_token');
+  const token = localStorage.getItem(AT_KEY);
 
   if (authentication) {
     return token ? <Outlet /> : <Navigate to={redirectPath} />;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #233

## 📖 구현 내용
- refresh, access Token을 분리하였습니다. 보안부분이 개선되었습니다.
- 로컬스토리지 키값을 변경하였습니다. 머지된다면 로컬스토리지를 정리해주세요.
- 조건을 수정하여 명시도를 높혔습니다.
- 인증 오류로 인해 토스트가 사라질때 랜딩페이지로 넘기도록 설정하였습니다.


## 🖼 구현 이미지

https://user-images.githubusercontent.com/82329983/233345163-9dfc6a3a-819a-40f8-a566-95754613894a.mov

## ✅ PR 포인트 & 궁금한 점
- token을 사용하는 페이지를 모두 바꾼다고 바꿨는데 빠진 부분이 있다면 알려주세요!
- 토스트에 authError props를 추가해서 이를 활용하여 랜딩페이지로 접근하는 부분이 어떤지 의견주시면 개선하겠습니다!