### PR TITLE
이메일 인증 핀코드 포커싱 개선

### DIFF
--- a/src/components/base/input/EmailInput.tsx
+++ b/src/components/base/input/EmailInput.tsx
@@ -16,7 +16,7 @@ import {
   Spinner,
   Text,
 } from '@chakra-ui/react';
-import { InputHTMLAttributes, useEffect, useState } from 'react';
+import { InputHTMLAttributes, useEffect, useRef, useState } from 'react';
 import {
   Control,
   FieldPath,
@@ -57,6 +57,7 @@ const EmailInput = <T extends FieldValues>({
   checkEmailState,
   certifyEmailState,
 }: UserInputProps<T>) => {
+  const ref = useRef<HTMLInputElement>(null);
   const { field, fieldState } = useController({ name, control });
 
   const [checkEmail, setCheckEmail] = checkEmailState;
@@ -99,8 +100,12 @@ const EmailInput = <T extends FieldValues>({
   };
 
   const handlePinCodeChange = (e: string) => {
-    if (e.length === 6) setPinCheckLoading(true);
-    else setPinCheckLoading(false);
+    if (e.length === 6) {
+      setPinCheckLoading(true);
+      ref.current?.focus();
+    } else {
+      setPinCheckLoading(false);
+    }
     setPinCode(e);
   };
 
@@ -185,7 +190,7 @@ const EmailInput = <T extends FieldValues>({
           <HStack>
             <PinInput onChange={handlePinCodeChange} isDisabled={certifyEmail} size='sm'>
               {[...Array(6)].map((_, i) => (
-                <PinInputField key={i} />
+                <PinInputField key={i} ref={i === 5 ? ref : null} />
               ))}
             </PinInput>
             {pinCheckLoading ? (

--- a/src/components/base/input/EmailInput.tsx
+++ b/src/components/base/input/EmailInput.tsx
@@ -6,12 +6,14 @@ import {
   FormErrorMessage,
   FormLabel,
   HStack,
+  Icon,
   Input,
   InputGroup,
   InputRightElement,
   PinInput,
   PinInputField,
   Spacer,
+  Spinner,
   Text,
 } from '@chakra-ui/react';
 import { InputHTMLAttributes, useEffect, useState } from 'react';
@@ -24,7 +26,7 @@ import {
   UseFormSetError,
   UseFormTrigger,
 } from 'react-hook-form';
-import { MdCancel } from 'react-icons/md';
+import { MdCancel, MdCheckCircleOutline } from 'react-icons/md';
 
 import {
   checkEmailCertificaitonCode,
@@ -56,12 +58,16 @@ const EmailInput = <T extends FieldValues>({
   certifyEmailState,
 }: UserInputProps<T>) => {
   const { field, fieldState } = useController({ name, control });
+
   const [checkEmail, setCheckEmail] = checkEmailState;
   const [certifyEmail, setCertifyEmail] = certifyEmailState;
+
   const [pinShow, setPinShow] = useState(false);
   const [pinCode, setPinCode] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const debouncePinCode = useDebounce<string>(pinCode, 300);
+  const debouncePinCode = useDebounce<string>(pinCode, 500);
+
+  const [sendCodeLoading, setSendCodeLoading] = useState(false);
+  const [pinCheckLoading, setPinCheckLoading] = useState(false);
 
   const handleCheckEmail = async () => {
     const checkBefore = await trigger(name);
@@ -82,17 +88,19 @@ const EmailInput = <T extends FieldValues>({
     const target = field.value;
     if (!checkEmail) return;
     try {
-      setIsLoading(true);
+      setSendCodeLoading(true);
       setPinShow(false);
       await sendEmailCertificationCode(target);
       setPinShow(true);
-      setIsLoading(false);
+      setSendCodeLoading(false);
     } catch (error) {
       console.error(error);
     }
   };
 
   const handlePinCodeChange = (e: string) => {
+    if (e.length === 6) setPinCheckLoading(true);
+    else setPinCheckLoading(false);
     setPinCode(e);
   };
 
@@ -106,6 +114,7 @@ const EmailInput = <T extends FieldValues>({
     } catch (error) {
       console.error(error);
     }
+    setPinCheckLoading(false);
   };
 
   useEffect(() => {
@@ -160,7 +169,7 @@ const EmailInput = <T extends FieldValues>({
           <Spacer />
           <Button
             mt='2'
-            isLoading={isLoading}
+            isLoading={sendCodeLoading}
             isDisabled={!checkEmail || certifyEmail}
             size='xs'
             onClick={handleSendCertificationCode}>
@@ -179,15 +188,16 @@ const EmailInput = <T extends FieldValues>({
                 <PinInputField key={i} />
               ))}
             </PinInput>
-            <Button
-              mt='2'
-              size='xs'
-              onClick={handleCertifyEmail}
-              isDisabled={certifyEmail}
-              isLoading={isLoading}
-              colorScheme={certifyEmail ? 'green' : 'red'}>
-              인증
-            </Button>
+            {pinCheckLoading ? (
+              <Spinner
+                speed='0.65s'
+                emptyColor='gray.200'
+                color='primary.red'
+                size='sm'
+              />
+            ) : (
+              <Icon color={certifyEmail ? 'green' : 'red'} as={MdCheckCircleOutline} />
+            )}
           </HStack>
         </Flex>
       )}

--- a/src/components/base/input/EmailInput.tsx
+++ b/src/components/base/input/EmailInput.tsx
@@ -32,6 +32,7 @@ import {
   sendEmailCertificationCode,
 } from '@/api/user';
 import Timer from '@/components/userSign/signUp/Timer';
+import useDebounce from '@/hooks/useDebounce';
 import { FORM_ERROR_MESSAGES } from '@/utils/constants/messages';
 
 interface UserInputProps<T extends FieldValues>
@@ -60,6 +61,7 @@ const EmailInput = <T extends FieldValues>({
   const [pinShow, setPinShow] = useState(false);
   const [pinCode, setPinCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const debouncePinCode = useDebounce<string>(pinCode, 300);
 
   const handleCheckEmail = async () => {
     const checkBefore = await trigger(name);
@@ -113,6 +115,12 @@ const EmailInput = <T extends FieldValues>({
     setCertifyEmail(false);
   }, [field.value]);
 
+  useEffect(() => {
+    if (debouncePinCode.length === 6) {
+      handleCertifyEmail();
+    }
+  }, [debouncePinCode]);
+
   return (
     <>
       <FormControl isInvalid={!!fieldState.error?.message}>
@@ -131,6 +139,7 @@ const EmailInput = <T extends FieldValues>({
           <Button
             size='sm'
             onClick={handleCheckEmail}
+            isDisabled={checkEmail}
             colorScheme={checkEmail ? 'green' : 'red'}>
             중복 확인
           </Button>
@@ -166,18 +175,16 @@ const EmailInput = <T extends FieldValues>({
           {!certifyEmail && <Timer certifyEmail={certifyEmail} setPinShow={setPinShow} />}
           <HStack>
             <PinInput onChange={handlePinCodeChange} isDisabled={certifyEmail} size='sm'>
-              <PinInputField />
-              <PinInputField />
-              <PinInputField />
-              <PinInputField />
-              <PinInputField />
-              <PinInputField />
+              {[...Array(6)].map((_, i) => (
+                <PinInputField key={i} />
+              ))}
             </PinInput>
             <Button
               mt='2'
               size='xs'
               onClick={handleCertifyEmail}
               isDisabled={certifyEmail}
+              isLoading={isLoading}
               colorScheme={certifyEmail ? 'green' : 'red'}>
               인증
             </Button>

--- a/src/components/base/input/NicknameInput.tsx
+++ b/src/components/base/input/NicknameInput.tsx
@@ -86,6 +86,7 @@ const NicknameInput = <T extends FieldValues>({
         <Button
           size='sm'
           onClick={handleCheckNickname}
+          isDisabled={checkNickname}
           colorScheme={checkNickname ? 'green' : 'red'}>
           중복 확인
         </Button>


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #237

## 📖 구현 내용
- 핀 복붙 or 6글자 입력시 자동 인증 기능
- debouce 활용, 과도한 인증 확인을 방어
- 인증 버튼 삭제, 아이콘 추가
- 아이콘 색으로 구분, 스피너 추가

## 🖼 구현 이미지

https://user-images.githubusercontent.com/82329983/234588944-44defa46-8743-4583-a7ee-10977c5021d3.mov



## ✅ PR 포인트 & 궁금한 점
- 구현 이미지를 확인하시고 마음에 안드는 부분이 있다면 말해주세요!
- <PinInputField /> 중복이 있어서 줄여봤습니다.. (댓글로 언급할게요)