### PR TITLE
이미지 드래그 제한

### DIFF
--- a/src/components/base/LargeLogo.tsx
+++ b/src/components/base/LargeLogo.tsx
@@ -1,5 +1,4 @@
-import { Center, Img } from '@chakra-ui/react';
-import styled from '@emotion/styled';
+import { Center, Image } from '@chakra-ui/react';
 
 type LargeLogoProps = {
   src: string;
@@ -8,13 +7,9 @@ type LargeLogoProps = {
 const LargeLogo = ({ src }: LargeLogoProps) => {
   return (
     <Center>
-      <Logo src={src} w='12.5rem' alt='우모 로고' />
+      <Image src={src} w='12.5rem' alt='우모 로고' />
     </Center>
   );
 };
-
-const Logo = styled(Img)`
-  -webkit-user-drag: none;
-`;
 
 export default LargeLogo;

--- a/src/components/main/MainHeader.tsx
+++ b/src/components/main/MainHeader.tsx
@@ -1,16 +1,11 @@
-import { Flex, Img } from '@chakra-ui/react';
-import styled from '@emotion/styled';
+import { Flex, Image } from '@chakra-ui/react';
 
 const MainHeader = () => {
   return (
     <Flex justify='center' h='4.0625rem' mt='1rem'>
-      <Logo src='/logo.svg' alt='우모 로고' />
+      <Image src='/logo.svg' alt='우모 로고' />
     </Flex>
   );
 };
 
 export default MainHeader;
-
-const Logo = styled(Img)`
-  -webkit-user-drag: none;
-`;

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -14,6 +14,14 @@ const globalStyle = css`
   body {
     height: 100%;
 
+    img {
+      -webkit-user-drag: none;
+      -khtml-user-drag: none;
+      -moz-user-drag: none;
+      -o-user-drag: none;
+      user-drag: none;
+    }
+
     .chakra-modal__content-container {
       font-family: 'Pretendard-Regular';
 


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #242 

## 📖 구현 내용
- 기존 `draggable='false'`를 설정하는 방식으로 진행하려다 추후를 위해 방법을 변경하였습니다.
- HTML 엘리먼트 확인시 Chakra에서 사진은 모두 img 태그로 활용한다는 점을 활용하였습니다.
- 글로벌 스타일에 img 태그 전체를 드래그 하지 못하도록 설정하였습니다.

## 🖼 구현 이미지

![May-09-2023 17-54-48](https://user-images.githubusercontent.com/82329983/237046167-7c3446e5-02aa-453d-9378-10da7e0d2bb6.gif)


## ✅ PR 포인트 & 궁금한 점
- 글로벌 스타일을 적용한 부분에 대해서 문제가 생길 부분이 있다면 알려주세요!