### PR TITLE
초대 페이지 무한 루프 버그 수정

### DIFF
--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -20,11 +20,11 @@ const InvitationPage = () => {
   const navigate = useNavigate();
   const { isOpen, onClose, onOpen } = useDisclosure();
   const [, setValue] = useLocalStorage('invitation', {});
-  const token = localStorage.getItem(AT_KEY);
+  const [storedValue] = useLocalStorage(AT_KEY, '');
   useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 
   useEffect(() => {
-    if (!token) {
+    if (!storedValue) {
       setValue({ roomId: roomId });
       Toast.show({
         title: '로그인이 필요한 서비스입니다.',
@@ -64,7 +64,7 @@ const InvitationPage = () => {
       onSuccess: () => {
         onOpen();
       },
-      enabled: !!token,
+      enabled: !!storedValue,
     }
   );
 

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -19,12 +19,12 @@ const InvitationPage = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
   const { isOpen, onClose, onOpen } = useDisclosure();
-  const [storedValue] = useLocalStorage(AT_KEY, {});
   const [, setValue] = useLocalStorage('invitation', {});
+  const token = localStorage.getItem(AT_KEY);
   useDocumentTitle('WuMoㅤ|ㅤ우리들의 모임');
 
   useEffect(() => {
-    if (!storedValue.accessToken) {
+    if (!token) {
       setValue({ roomId: roomId });
       Toast.show({
         title: '로그인이 필요한 서비스입니다.',
@@ -64,7 +64,7 @@ const InvitationPage = () => {
       onSuccess: () => {
         onOpen();
       },
-      enabled: !!storedValue.accessToken,
+      enabled: !!token,
     }
   );
 


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #241

## 📖 구현 내용
- 초대페이지에서 사용자 토큰 여부가 제대로 확인이 안되고 있어서 무한 루프 버그가 생기고 있었습니다! 그래서 로컬스토리지 훅 사용하는 부분을 커스텀 훅 사용하지 않고 getItem 하도록 변경하였습니다.

## 🖼 구현 이미지
없음

## ✅ PR 포인트 & 궁금한 점
-