### PR TITLE
모임 목록 페이지 데이터 분리, 성능 개선 작업

### DIFF
--- a/src/components/party/partyList/PartyList.tsx
+++ b/src/components/party/partyList/PartyList.tsx
@@ -2,17 +2,12 @@ import { Box, Center, Spinner, Text } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyPartyList } from '@/api/main';
-import { MyPartyList } from '@/types/party';
+import { MyPartyList, PartyListProps } from '@/types/party';
+import { EMPTY_PARTY_TEXT } from '@/utils/constants/party';
 
 import PartyListCard from './PartyListCard';
 
-const isEmptyText = {
-  onGoing: '진행중인',
-  completed: '완료된',
-  all: '참여중인',
-};
-
-const PartyList = ({ partyType }: { partyType: 'onGoing' | 'completed' | 'all' }) => {
+const PartyList = ({ partyType }: PartyListProps) => {
   const {
     data: PartyList,
     isLoading,
@@ -34,7 +29,7 @@ const PartyList = ({ partyType }: { partyType: 'onGoing' | 'completed' | 'all' }
       <>
         <Center pt='20'>
           <Text fontSize='1rem' fontWeight='bold'>
-            아직 {isEmptyText[partyType]} 모임이 없어요. 😥
+            아직 {EMPTY_PARTY_TEXT[partyType]} 모임이 없어요. 😥
           </Text>
         </Center>
       </>

--- a/src/components/party/partyList/PartyList.tsx
+++ b/src/components/party/partyList/PartyList.tsx
@@ -2,12 +2,12 @@ import { Box, Center, Spinner, Text } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyPartyList } from '@/api/main';
-import { MyPartyList, PartyListProps } from '@/types/party';
+import { MyPartyList, PartyListProp } from '@/types/party';
 import { EMPTY_PARTY_TEXT } from '@/utils/constants/party';
 
 import PartyListCard from './PartyListCard';
 
-const PartyList = ({ partyType }: PartyListProps) => {
+const PartyList = ({ partyType }: PartyListProp) => {
   const {
     data: PartyList,
     isLoading,

--- a/src/components/party/partyList/PartyList.tsx
+++ b/src/components/party/partyList/PartyList.tsx
@@ -1,4 +1,4 @@
-import { Box, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from '@chakra-ui/react';
+import { Box, Center, Spinner, Text } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyPartyList } from '@/api/main';
@@ -6,79 +6,55 @@ import { MyPartyList } from '@/types/party';
 
 import PartyListCard from './PartyListCard';
 
-const PartyList = () => {
+const isEmptyText = {
+  onGoing: '진행중인',
+  completed: '완료된',
+  all: '참여중인',
+};
+
+const PartyList = ({ partyType }: { partyType: 'onGoing' | 'completed' | 'all' }) => {
   const {
-    data: onGoingPartyList,
-    isLoading: onGoingLoading,
-    isError: onGoingError,
+    data: PartyList,
+    isLoading,
+    isError,
   } = useQuery<MyPartyList>(
-    ['onGoingPartyList'],
-    () => fetchMyPartyList({ partyType: 'ONGOING', pageSize: 1000 }),
+    [`${partyType}PartyList`],
+    () =>
+      fetchMyPartyList({
+        partyType: partyType.toUpperCase() as 'ONGOING' | 'COMPLETED' | 'ALL',
+        pageSize: 1000,
+      }),
     {
       staleTime: 10000,
     }
   );
 
-  const {
-    data: completedPartyList,
-    isLoading: completedLoading,
-    isError: completedError,
-  } = useQuery<MyPartyList>(
-    ['completedPartyList'],
-    () => fetchMyPartyList({ partyType: 'COMPLETED', pageSize: 1000 }),
-    {
-      staleTime: 10000,
-    }
-  );
-
-  if (onGoingLoading || completedLoading) return <></>;
-  if (onGoingError || completedError) return <></>;
+  if (PartyList?.party.length === 0)
+    return (
+      <>
+        <Center pt='20'>
+          <Text fontSize='1rem' fontWeight='bold'>
+            아직 {isEmptyText[partyType]} 모임이 없어요. 😥
+          </Text>
+        </Center>
+      </>
+    );
+  if (isLoading)
+    return (
+      <Center mt='20'>
+        <Spinner speed='0.65s' emptyColor='gray.200' color='primary.red' size='xl' />
+      </Center>
+    );
+  if (isError) return <></>;
 
   return (
-    <Box pt='14'>
-      <Tabs isFitted colorScheme='red'>
-        <TabList pos='fixed' maxW='maxWidth.mobile' w='100%' zIndex='10' bg='white'>
-          <Tab>진행중인 모임</Tab>
-          <Tab>완료된 모임</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel p='2'>
-            {onGoingPartyList.party.length === 0 ? (
-              <Box pt='20' textAlign='center'>
-                <Text fontSize='1rem' fontWeight='bold'>
-                  아직 진행중인 모임이 없어요. 😥
-                </Text>
-              </Box>
-            ) : (
-              <>
-                {onGoingPartyList.party.map((party, idx) => (
-                  <Box pt={idx === 0 ? '10' : '0'} mt='4' key={party.id}>
-                    <PartyListCard {...party} />
-                  </Box>
-                ))}
-              </>
-            )}
-          </TabPanel>
-          <TabPanel p='2'>
-            {completedPartyList.party.length === 0 ? (
-              <Box pt='20' textAlign='center'>
-                <Text fontSize='1rem' fontWeight='bold'>
-                  아직 완료된 모임이 없어요. 😥
-                </Text>
-              </Box>
-            ) : (
-              <>
-                {completedPartyList.party.map((party, idx) => (
-                  <Box pt={idx === 0 ? '10' : '0'} mt='4' key={party.id}>
-                    <PartyListCard {...party} />
-                  </Box>
-                ))}
-              </>
-            )}
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Box>
+    <>
+      {PartyList.party.map((party, idx) => (
+        <Box pt={idx === 0 ? '10' : '0'} mt='4' key={party.id}>
+          <PartyListCard {...party} />
+        </Box>
+      ))}
+    </>
   );
 };
 

--- a/src/components/party/partyList/PartyList.tsx
+++ b/src/components/party/partyList/PartyList.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyPartyList } from '@/api/main';
 import { MyPartyList, PartyListProp } from '@/types/party';
-import { EMPTY_PARTY_TEXT } from '@/utils/constants/party';
+import { partyOptions } from '@/utils/constants/party';
 
 import PartyListCard from './PartyListCard';
 
@@ -16,7 +16,7 @@ const PartyList = ({ partyType }: PartyListProp) => {
     [`${partyType}PartyList`],
     () =>
       fetchMyPartyList({
-        partyType: partyType.toUpperCase() as 'ONGOING' | 'COMPLETED' | 'ALL',
+        partyType: partyOptions[partyType].partyStatus,
         pageSize: 1000,
       }),
     {
@@ -29,7 +29,7 @@ const PartyList = ({ partyType }: PartyListProp) => {
       <>
         <Center pt='20'>
           <Text fontSize='1rem' fontWeight='bold'>
-            아직 {EMPTY_PARTY_TEXT[partyType]} 모임이 없어요. 😥
+            아직 {partyOptions[partyType].emptyPartyText} 모임이 없어요. 😥
           </Text>
         </Center>
       </>

--- a/src/components/party/partyList/PartyListGrid.tsx
+++ b/src/components/party/partyList/PartyListGrid.tsx
@@ -16,7 +16,7 @@ const PartyListGrid = () => {
     data: myPartyList,
     isLoading,
     isError,
-  } = useQuery<MyPartyList>(['myPartyList'], () => fetchMyPartyList(parameter), {
+  } = useQuery<MyPartyList>([`onGoingPartyList`], () => fetchMyPartyList(parameter), {
     staleTime: 10000,
   });
 

--- a/src/components/party/partyList/PartyListTabs.tsx
+++ b/src/components/party/partyList/PartyListTabs.tsx
@@ -1,0 +1,26 @@
+import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+
+import PartyList from './PartyList';
+
+const PartyListTabs = () => {
+  return (
+    <Box pt='14'>
+      <Tabs isLazy isFitted colorScheme='red'>
+        <TabList pos='fixed' maxW='maxWidth.mobile' w='100%' zIndex='10' bg='white'>
+          <Tab>진행중인 모임</Tab>
+          <Tab>완료된 모임</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel p='2'>
+            <PartyList partyType='onGoing' />
+          </TabPanel>
+          <TabPanel p='2'>
+            <PartyList partyType='completed' />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+};
+
+export default PartyListTabs;

--- a/src/pages/PartyListPage.tsx
+++ b/src/pages/PartyListPage.tsx
@@ -1,14 +1,14 @@
 import useDocumentTitle from '@/hooks/useDocumentTitle';
 
 import BackNavigation from '../components/navigation/BackNavigation';
-import PartyList from '../components/party/partyList/PartyList';
+import PartyListTabs from '../components/party/partyList/PartyListTabs';
 
 const PartyListPage = () => {
   useDocumentTitle('WuMoㅤ|ㅤ내 모임');
   return (
     <>
       <BackNavigation title='내 모임 목록' />
-      <PartyList />
+      <PartyListTabs />
     </>
   );
 };

--- a/src/pages/PartyListPage.tsx
+++ b/src/pages/PartyListPage.tsx
@@ -1,7 +1,6 @@
+import BackNavigation from '@/components/navigation/BackNavigation';
+import PartyListTabs from '@/components/party/partyList/PartyListTabs';
 import useDocumentTitle from '@/hooks/useDocumentTitle';
-
-import BackNavigation from '../components/navigation/BackNavigation';
-import PartyListTabs from '../components/party/partyList/PartyListTabs';
 
 const PartyListPage = () => {
   useDocumentTitle('WuMoㅤ|ㅤ내 모임');

--- a/src/types/party.d.ts
+++ b/src/types/party.d.ts
@@ -74,6 +74,10 @@ export type MyPartyList = {
   lastId: number;
 };
 
+export type PartyListProps = {
+  partyType: 'onGoing' | 'completed' | 'all';
+};
+
 export type MyPartyListParams = {
   partyType: 'ONGOING' | 'COMPLETED' | 'ALL';
   cursorId?: number;

--- a/src/types/party.d.ts
+++ b/src/types/party.d.ts
@@ -74,7 +74,7 @@ export type MyPartyList = {
   lastId: number;
 };
 
-export type PartyListProps = {
+export type PartyListProp = {
   partyType: 'onGoing' | 'completed' | 'all';
 };
 

--- a/src/utils/constants/party.ts
+++ b/src/utils/constants/party.ts
@@ -38,3 +38,9 @@ export const partyRoleList = [
 ];
 
 export const PLACE_DESCRIPTION_MAX_LENGTH = 50;
+
+export const EMPTY_PARTY_TEXT = {
+  onGoing: '진행중인',
+  completed: '완료된',
+  all: '참여중인',
+} as const;

--- a/src/utils/constants/party.ts
+++ b/src/utils/constants/party.ts
@@ -39,8 +39,17 @@ export const partyRoleList = [
 
 export const PLACE_DESCRIPTION_MAX_LENGTH = 50;
 
-export const EMPTY_PARTY_TEXT = {
-  onGoing: '진행중인',
-  completed: '완료된',
-  all: '참여중인',
+export const partyOptions = {
+  onGoing: {
+    partyStatus: 'ONGOING',
+    emptyPartyText: '진행중인',
+  },
+  completed: {
+    partyStatus: 'COMPLETED',
+    emptyPartyText: '완료된',
+  },
+  all: {
+    partyStatus: 'ALL',
+    emptyPartyText: '참여중인',
+  },
 } as const;


### PR DESCRIPTION
## 💡 Linked Issues
<!-- ex. Resolve: #1 -->
Resolve: #245

## 📖 구현 내용
- PartyListTabs와 PartyList 컴포넌트를 분리하였습니다.
- 기존 내 모임 탭에 접근하면 한꺼번에 데이터를 가져오던 부분을 lazy로 분리하였습니다.
- 프로필 페이지의 리액트쿼리 키값과 모임 키값을 통일하였습니다.

## 🖼 구현 이미지
- 기존 fetch
![스크린샷 2023-06-09 오후 9 40 22](https://github.com/prgrms-web-devcourse/Team-5YES-WuMo-FE/assets/82329983/b61cbb96-4180-439b-961e-6ed3a1ff9e77)

- 수정 후 fetch
![스크린샷 2023-06-09 오후 9 40 57](https://github.com/prgrms-web-devcourse/Team-5YES-WuMo-FE/assets/82329983/e16d107d-ab40-440c-8f6e-e1cc00143f80)

- 동작

https://github.com/prgrms-web-devcourse/Team-5YES-WuMo-FE/assets/82329983/bc82d603-736c-489e-bc4a-504dfbdd894a


## ✅ PR 포인트 & 궁금한 점
- PartyList 재사용성을 높혀보려고 시도하였는데 개선할 부분이 있다면 리뷰 남겨주세요!